### PR TITLE
training script with fake data loader

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "sentencepiece>=0.2.0",
     "typing-extensions>=4.12.2",
     "tyro>=0.8.14",
+    "tqdm",
 ]
 
 [project.urls]

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -1,0 +1,199 @@
+import dataclasses
+from functools import partial
+import logging
+import tqdm
+import numpy as np
+
+from flax.training import common_utils
+from flax.training import train_state
+import jax
+from jax.experimental import mesh_utils
+from jax.experimental import multihost_utils
+import jax.numpy as jnp
+import optax
+
+import openpi.base.array_typing as at
+import openpi.models.common as _common
+import openpi.models.model as _model
+import openpi.models.pi0 as pi0
+import openpi.training.utils as training_utils
+import openpi.training.data_loader as _data_loader
+import openpi.training.optimizer as _optimizer
+import openpi.training.checkpoints as _checkpoints
+
+
+# TODO(kevin): Swap with proper config class.
+@dataclasses.dataclass
+class Config:
+    keep_interval: int = 5000
+    load_pretrained_weights: str | None = None
+    num_train_steps: int = 2000_000
+    log_interval: int = 100
+    save_interval: int = 1000
+
+
+def init_logging() -> None:
+    """Custom logging format for better readability."""
+    level_mapping = {"DEBUG": "D", "INFO": "I", "WARNING": "W", "ERROR": "E", "CRITICAL": "C"}
+
+    class CustomFormatter(logging.Formatter):
+        def format(self, record):
+            record.levelname = level_mapping.get(record.levelname, record.levelname)
+            return super().format(record)
+
+    formatter = CustomFormatter(
+        fmt="%(asctime)s.%(msecs)03d [%(levelname)s] %(message)-80s (%(process)d:%(filename)s:%(lineno)s)",
+        datefmt="%H:%M:%S",
+    )
+    handler = logging.StreamHandler()
+    handler.setFormatter(formatter)
+
+    logger = logging.getLogger()
+    logger.setLevel(logging.INFO)
+    logger.addHandler(handler)
+
+
+def init_model(
+    config: Config,
+    model: _model.Model,
+    init_rng: at.KeyArrayLike,
+    data: tuple[_common.Observation, _common.Actions],
+    mesh: jax.sharding.Mesh,
+    *,
+    resume: bool,
+) -> tuple[train_state.TrainState, jax.sharding.NamedSharding]:
+    def init_train_state(
+        rng: at.KeyArrayLike, data: tuple[_common.Observation, _common.Actions], model: _model.Model
+    ) -> train_state.TrainState:
+        rng, model_rng = jax.random.split(rng)
+        observation, actions = data
+        model = model.init_params(model_rng, observation, actions)
+        weight_decay_mask = None
+        freeze_mask = None
+
+        tx = _optimizer.adamw_optimizer(
+            lr=_optimizer.cosine_decay_schedule(), weight_decay_mask=weight_decay_mask, freeze_mask=freeze_mask
+        )
+
+        def loss_fn(
+            params: at.Params, rng: at.KeyArrayLike, observation: _common.Observation, actions: _common.Actions
+        ):
+            chunked_loss = model.compute_loss(rng, observation, actions, params={"params": params}, train=True)
+            return jnp.mean(chunked_loss)
+
+        return train_state.TrainState.create(
+            apply_fn=loss_fn,
+            params=model.params["params"],
+            tx=tx,
+        )
+
+    replicated_sharding = jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec())
+    data_parallel_sharding = jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec(("batch",)))
+    state_sharding = replicated_sharding
+    state = jax.eval_shape(init_train_state, init_rng, data, model)
+    if resume:
+        return state, state_sharding
+    # jax typechecking doesn't like sharding and jit
+    with at.disable_typechecking():
+        state = jax.jit(
+            partial(init_train_state, model=model),
+            in_shardings=(replicated_sharding, data_parallel_sharding),
+            out_shardings=state_sharding,
+        )(init_rng, data)
+    # TODO: Improve this to not have two copies of the weight in memory.
+    if config.load_pretrained_weights:
+        state = _checkpoints.restore_weights(config.load_pretrained_weights, state, state_sharding)
+    return state, state_sharding
+
+
+def train_step(
+    rng: at.KeyArrayLike, state: train_state.TrainState, batch: tuple[_common.Observation, _common.Actions]
+) -> train_state.TrainState:
+    old_params = state.params
+    train_rng = jax.random.fold_in(rng, state.step)
+    observation, actions = batch
+    loss, grads = jax.value_and_grad(state.apply_fn)(state.params, train_rng, observation, actions)
+    state = state.apply_gradients(grads=grads)
+
+    used_grads = jax.tree.map(lambda g, old, new: g if old is not new else None, grads, old_params, state.params)
+    kernel_mask = training_utils.mask_from_regex(r".*\['kernel'\]", state.params)
+    kernel_params = jax.tree.map(lambda p, m: p if m else None, state.params, kernel_mask)
+    info = {
+        "loss": loss,
+        "grad_norm": optax.global_norm(used_grads),
+        "param_norm": optax.global_norm(kernel_params),
+    }
+    return state, info
+
+
+def main(checkpoint_dir: str, seed: int, *, overwrite: bool = False, resume: bool = False):
+    init_logging()
+    config = Config()
+    jax.distributed.initialize()
+    jax.config.update("jax_threefry_partitionable", True)
+
+    rng = jax.random.key(seed)
+    rng, init_rng = jax.random.split(rng)
+
+    # data parallel only
+    mesh_shape = (jax.device_count(),)
+    mesh = jax.sharding.Mesh(mesh_utils.create_device_mesh(mesh_shape), ("batch",))
+    data_parallel_sharding = jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec(("batch",)))
+    replicated_sharding = jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec())
+
+    checkpoint_manager, resuming = _checkpoints.initialize_checkpoint(
+        checkpoint_dir, keep_interval=config.keep_interval, overwrite=overwrite, resume=resume
+    )
+    multihost_utils.sync_global_devices("init_checkpoint")
+
+    model = _model.Model(module=pi0.Module(), action_dim=24, action_horizon=50, max_token_len=48)
+    data_loader = _data_loader.fake_init_data_loader(model, local_batch_size=16, dp_sharding=data_parallel_sharding)
+    batch = next(data_loader)
+    logging.info(f"Data loader initialized: {training_utils.to_tree_info(batch)}")
+    multihost_utils.sync_global_devices("init_dataloader")
+
+    train_state, train_state_sharding = init_model(config, model, init_rng, batch, mesh, resume=resuming)
+    logging.info(f"Initialized train state: {training_utils.to_tree_info(train_state.params)}")
+    multihost_utils.sync_global_devices("init_train_state")
+
+    if resuming:
+        train_state = _checkpoints.restore_state(checkpoint_manager, train_state)
+        multihost_utils.sync_global_devices("resume_training")
+
+    # jax typechecking doesn't like sharding and jit
+    ptrain_step = jax.jit(
+        train_step,
+        in_shardings=(replicated_sharding, train_state_sharding, data_parallel_sharding),
+        out_shardings=(train_state_sharding, replicated_sharding),
+        donate_argnums=(1,),
+    )
+
+    start_step = int(train_state.step)
+    pbar = tqdm.trange(
+        start_step,
+        config.num_train_steps,
+        initial=start_step,
+        total=config.num_train_steps,
+        dynamic_ncols=True,
+        disable=jax.process_index() != 0,
+    )
+
+    infos = []
+    for step in pbar:
+        with at.disable_typechecking():
+            train_state, info = ptrain_step(rng, train_state, batch)
+            infos.append(info)
+        if step % config.log_interval == 0:
+            stacked_infos = common_utils.stack_forest(infos)
+            reduced_info = jax.device_get(jax.tree_util.tree_map(jnp.mean, stacked_infos))
+            logging.info(f"Step {step}: {reduced_info}")
+            infos = []
+        with at.disable_typechecking():
+            batch = next(data_loader)
+
+        if step % config.save_interval == 0:
+            _checkpoints.save_state(checkpoint_manager, train_state, step)
+
+
+if __name__ == "__main__":
+    main(checkpoint_dir="/tmp/openpi/exp", seed=42, overwrite=False, resume=True)

--- a/src/openpi/training/checkpoints.py
+++ b/src/openpi/training/checkpoints.py
@@ -1,0 +1,80 @@
+import logging
+import orbax.checkpoint as ocp
+from etils import epath
+import jax
+from flax.training import train_state
+import openpi.models.model as _model
+from jax.experimental import multihost_utils
+
+
+def initialize_checkpoint(
+    checkpoint_dir: str, keep_interval: int, *, overwrite: bool, resume: bool
+) -> tuple[ocp.CheckpointManager, bool]:
+    checkpoint_dir = epath.Path(checkpoint_dir)
+    resuming = False
+    if checkpoint_dir.exists():
+        if overwrite:
+            if jax.process_index() == 0:
+                checkpoint_dir.rmtree()
+                checkpoint_dir.mkdir(parents=True, exist_ok=True)
+                logging.info(f"Wiped checkpoint directory {checkpoint_dir}")
+        elif resume:
+            resuming = True
+        else:
+            raise FileExistsError(f"Checkpoint directory {checkpoint_dir} already exists")
+
+    if jax.process_index() == 0:
+        checkpoint_dir.mkdir(parents=True, exist_ok=True)
+
+    multihost_utils.sync_global_devices("checkpoint dir created")
+
+    mngr = ocp.CheckpointManager(
+        checkpoint_dir,
+        options=ocp.CheckpointManagerOptions(
+            max_to_keep=1,
+            keep_period=keep_interval,
+            create=False,
+            async_options=ocp.AsyncOptions(timeout_secs=7200),
+        ),
+    )
+
+    # special case: the checkpoint directory exists and the user requests to resume training, but the training run did
+    # not get to the first checkpoint saved. in this case, we don't actually want the train script to try and restore a
+    # checkpoint, since it will fail.
+    if resuming and tuple(mngr.all_steps()) in [(), (0,)]:
+        logging.info("Checkpoint directory exists, but does not contain any checkpoints. Aborting resume.")
+        resuming = False
+
+    return mngr, resuming
+
+
+def restore_weights(
+    checkpoint_dir: str,
+    state: train_state.TrainState,
+    sharding: jax.sharding.NamedSharding,
+) -> train_state.TrainState:
+    """Restores pretrained weights from a given directory. Does not restore optimizer state or model configuration.
+
+    Args:
+        checkpoint_dir: Directory to load the checkpoint from.
+        state: The target TrainState to restore into.
+    """
+    logging.info(f"Restoring weights from {checkpoint_dir}")
+    path = epath.Path(checkpoint_dir).expanduser().resolve()
+    return state.replace(model=_model.restore_params(state.model, path, sharding=sharding))
+
+
+def save_state(checkpoint_manager: ocp.CheckpointManager, state: train_state.TrainState, step: int) -> None:
+    checkpoint_manager.save(step, args=ocp.args.PyTreeSave(state))
+
+
+def restore_state(
+    checkpoint_manager: ocp.CheckpointManager, state: train_state.TrainState, step: int | None = None
+) -> train_state.TrainState:
+    if step is None:
+        step = checkpoint_manager.latest_step()
+
+    # providing a target `TrainState` to `FlaxRestore` causes the serialized metadata to be ignored, and the
+    # provided object to be used to validate shapes/dtypes/structure instead.
+    logging.info(f"Restoring checkpoint from {checkpoint_manager.directory}, step {step}")
+    return checkpoint_manager.restore(step, args=ocp.args.PyTreeRestore(state))

--- a/src/openpi/training/data_loader.py
+++ b/src/openpi/training/data_loader.py
@@ -1,0 +1,40 @@
+import jax
+import jax.numpy as jnp
+import openpi.base.array_typing as at
+import openpi.models.model as _model
+import openpi.models.common as _common
+from functools import partial
+
+from flax.training import common_utils
+from typing import Iterator
+
+
+def fake_init_data_loader(
+    model: _model.Model, local_batch_size: int, dp_sharding: jax.sharding.Sharding
+) -> Iterator[tuple[_common.Observation, _common.Actions]]:
+    """Returns a faked (and infinite) data loader with input spec."""
+    observation_spec, action_spec = _model.create_inputs_spec(model, batch_size=local_batch_size)
+    print(observation_spec)
+    print(action_spec)
+
+    def make_from_spec(spec: jax.ShapeDtypeStruct, rng: at.KeyArrayLike):
+        if spec.dtype == jnp.float32:
+            return jax.random.uniform(rng, shape=spec.shape, minval=-1.0, maxval=1.0)
+        if spec.dtype == jnp.int32:
+            return jax.random.randint(rng, shape=spec.shape, minval=0, maxval=2048)
+        return jnp.zeros(shape=spec.shape, dtype=spec.dtype)
+
+    def _to_dp_array(local_arr: jax.Array):
+        global_shape = (local_arr.shape[0] * jax.process_count(), *local_arr.shape[1:])
+        return jax.make_array_from_process_local_data(dp_sharding, local_arr, global_shape)
+
+    def data_loader():
+        rng = jax.random.key(0)
+        while True:
+            rng, data_rng = jax.random.split(rng)
+            observation = jax.tree.map(partial(make_from_spec, rng=data_rng), observation_spec)
+            action = jax.tree.map(partial(make_from_spec, rng=data_rng), action_spec)
+            # Obs(stacked on leaves) -> Obs(global array)
+            yield jax.tree.map(_to_dp_array, observation), jax.tree.map(_to_dp_array, action)
+
+    return data_loader()

--- a/src/openpi/training/optimizer.py
+++ b/src/openpi/training/optimizer.py
@@ -1,0 +1,43 @@
+import optax
+import jax
+import openpi.base.array_typing as at
+
+
+def cosine_decay_schedule(
+    warmup_steps: int = 1_000, peak_lr: float = 5e-5, decay_steps: int = int(1e9), decay_lr: float = 5e-5
+) -> optax.Schedule:
+    return optax.warmup_cosine_decay_schedule(
+        init_value=peak_lr / (warmup_steps + 1),
+        peak_value=peak_lr,
+        warmup_steps=warmup_steps,
+        decay_steps=decay_steps,
+        end_value=decay_lr,
+    )
+
+
+def adamw_optimizer(
+    lr: optax.ScalarOrSchedule,
+    b1: float = 0.9,
+    b2: float = 0.95,
+    eps: float = 1e-8,
+    clip_gradient_norm: float | None = 100.0,
+    ema_decay: float = 0.999,
+    weight_decay: float = 1e-4,
+    weight_decay_mask: at.PyTree | None = None,
+    freeze_mask: at.PyTree | None = None,
+) -> optax.GradientTransformation:
+    tx = optax.adamw(lr, b1=b1, b2=b2, eps=eps, weight_decay=weight_decay, mask=weight_decay_mask)
+
+    if freeze_mask is not None:
+        tx = optax.multi_transform(
+            {"online": tx, "offline": optax.set_to_zero()},
+            jax.tree_util.tree_map(lambda x: "offline" if x else "online", freeze_mask),
+        )
+
+    if clip_gradient_norm is not None:
+        tx = optax.chain(optax.clip_by_global_norm(clip_gradient_norm), tx)
+
+    if ema_decay != 0:
+        tx = optax.chain(optax.ema(ema_decay), tx)
+
+    return tx

--- a/src/openpi/training/utils.py
+++ b/src/openpi/training/utils.py
@@ -1,0 +1,26 @@
+from collections.abc import Callable
+import re
+
+import jax
+
+from openpi.base import array_typing as at
+
+
+@at.typecheck
+def mask_from_regex(regex: str, pytree: at.PyTree) -> at.PyTree[bool]:
+    compiled = re.compile(regex)
+    return jax.tree_util.tree_map_with_path(
+        lambda path, _: compiled.fullmatch(jax.tree_util.keystr(path)) is not None, pytree
+    )
+
+
+@at.typecheck
+def to_readable_mask_info(mask: at.PyTree[bool], interp_func: Callable[[bool], str]) -> str:
+    tree, _ = jax.tree_util.tree_flatten_with_path(mask)
+    return "\n".join(f"{jax.tree_util.keystr(path)}: {interp_func(value)}" for path, value in tree)
+
+
+@at.typecheck
+def to_tree_info(tree: at.PyTree) -> str:
+    tree, _ = jax.tree_util.tree_flatten_with_path(tree)
+    return "\n".join(f"{jax.tree_util.keystr(path)}: {value.shape}@{value.dtype}" for path, value in tree)

--- a/uv.lock
+++ b/uv.lock
@@ -667,7 +667,9 @@ name = "nvidia-cuda-cupti-cu12"
 version = "12.6.80"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/8b/2f6230cb715646c3a9425636e513227ce5c93c4d65823a734f4bb86d43c3/nvidia_cuda_cupti_cu12-12.6.80-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:166ee35a3ff1587f2490364f90eeeb8da06cd867bd5b701bf7f9a02b78bc63fc", size = 8236764 },
     { url = "https://files.pythonhosted.org/packages/25/0f/acb326ac8fd26e13c799e0b4f3b2751543e1834f04d62e729485872198d4/nvidia_cuda_cupti_cu12-12.6.80-py3-none-manylinux2014_aarch64.whl", hash = "sha256:358b4a1d35370353d52e12f0a7d1769fc01ff74a191689d3870b2123156184c4", size = 8236756 },
+    { url = "https://files.pythonhosted.org/packages/49/60/7b6497946d74bcf1de852a21824d63baad12cd417db4195fc1bfe59db953/nvidia_cuda_cupti_cu12-12.6.80-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6768bad6cab4f19e8292125e5f1ac8aa7d1718704012a0e3272a6f61c4bce132", size = 8917980 },
     { url = "https://files.pythonhosted.org/packages/a5/24/120ee57b218d9952c379d1e026c4479c9ece9997a4fb46303611ee48f038/nvidia_cuda_cupti_cu12-12.6.80-py3-none-manylinux2014_x86_64.whl", hash = "sha256:a3eff6cdfcc6a4c35db968a06fcadb061cbc7d6dde548609a941ff8701b98b73", size = 8917972 },
     { url = "https://files.pythonhosted.org/packages/1c/81/7796f096afaf726796b1b648f3bc80cafc61fe7f77f44a483c89e6c5ef34/nvidia_cuda_cupti_cu12-12.6.80-py3-none-win_amd64.whl", hash = "sha256:bbe6ae76e83ce5251b56e8c8e61a964f757175682bbad058b170b136266ab00a", size = 5724175 },
 ]
@@ -687,7 +689,9 @@ name = "nvidia-cuda-runtime-cu12"
 version = "12.6.77"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/ea/590b2ac00d772a8abd1c387a92b46486d2679ca6622fd25c18ff76265663/nvidia_cuda_runtime_cu12-12.6.77-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6116fad3e049e04791c0256a9778c16237837c08b27ed8c8401e2e45de8d60cd", size = 908052 },
     { url = "https://files.pythonhosted.org/packages/b7/3d/159023799677126e20c8fd580cca09eeb28d5c5a624adc7f793b9aa8bbfa/nvidia_cuda_runtime_cu12-12.6.77-py3-none-manylinux2014_aarch64.whl", hash = "sha256:d461264ecb429c84c8879a7153499ddc7b19b5f8d84c204307491989a365588e", size = 908040 },
+    { url = "https://files.pythonhosted.org/packages/e1/23/e717c5ac26d26cf39a27fbc076240fad2e3b817e5889d671b67f4f9f49c5/nvidia_cuda_runtime_cu12-12.6.77-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ba3b56a4f896141e25e19ab287cd71e52a6a0f4b29d0d31609f60e3b4d5219b7", size = 897690 },
     { url = "https://files.pythonhosted.org/packages/f0/62/65c05e161eeddbafeca24dc461f47de550d9fa8a7e04eb213e32b55cfd99/nvidia_cuda_runtime_cu12-12.6.77-py3-none-manylinux2014_x86_64.whl", hash = "sha256:a84d15d5e1da416dd4774cb42edf5e954a3e60cc945698dc1d5be02321c44dc8", size = 897678 },
     { url = "https://files.pythonhosted.org/packages/fa/76/4c80fa138333cc975743fd0687a745fccb30d167f906f13c1c7f9a85e5ea/nvidia_cuda_runtime_cu12-12.6.77-py3-none-win_amd64.whl", hash = "sha256:86c58044c824bf3c173c49a2dbc7a6c8b53cb4e4dca50068be0bf64e9dab3f7f", size = 891773 },
 ]
@@ -713,7 +717,9 @@ dependencies = [
     { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/37/c50d2b2f2c07e146776389e3080f4faf70bcc4fa6e19d65bb54ca174ebc3/nvidia_cufft_cu12-11.3.0.4-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d16079550df460376455cba121db6564089176d9bac9e4f360493ca4741b22a6", size = 200164144 },
     { url = "https://files.pythonhosted.org/packages/ce/f5/188566814b7339e893f8d210d3a5332352b1409815908dad6a363dcceac1/nvidia_cufft_cu12-11.3.0.4-py3-none-manylinux2014_aarch64.whl", hash = "sha256:8510990de9f96c803a051822618d42bf6cb8f069ff3f48d93a8486efdacb48fb", size = 200164135 },
+    { url = "https://files.pythonhosted.org/packages/8f/16/73727675941ab8e6ffd86ca3a4b7b47065edcca7a997920b831f8147c99d/nvidia_cufft_cu12-11.3.0.4-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ccba62eb9cef5559abd5e0d54ceed2d9934030f51163df018532142a8ec533e5", size = 200221632 },
     { url = "https://files.pythonhosted.org/packages/60/de/99ec247a07ea40c969d904fc14f3a356b3e2a704121675b75c366b694ee1/nvidia_cufft_cu12-11.3.0.4-py3-none-manylinux2014_x86_64.whl", hash = "sha256:768160ac89f6f7b459bee747e8d175dbf53619cfe74b2a5636264163138013ca", size = 200221622 },
     { url = "https://files.pythonhosted.org/packages/b4/38/36fd800cec8f6e89b7c1576edaaf8076e69ec631644cdbc1b5f2e2b5a9df/nvidia_cufft_cu12-11.3.0.4-py3-none-win_amd64.whl", hash = "sha256:6048ebddfb90d09d2707efb1fd78d4e3a77cb3ae4dc60e19aab6be0ece2ae464", size = 199356881 },
 ]
@@ -729,7 +735,9 @@ dependencies = [
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/93/17/dbe1aa865e4fdc7b6d4d0dd308fdd5aaab60f939abfc0ea1954eac4fb113/nvidia_cusolver_cu12-11.7.1.2-py3-none-manylinux2014_aarch64.whl", hash = "sha256:0ce237ef60acde1efc457335a2ddadfd7610b892d94efee7b776c64bb1cac9e0", size = 157833628 },
+    { url = "https://files.pythonhosted.org/packages/f0/6e/c2cf12c9ff8b872e92b4a5740701e51ff17689c4d726fca91875b07f655d/nvidia_cusolver_cu12-11.7.1.2-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e9e49843a7707e42022babb9bcfa33c29857a93b88020c4e4434656a655b698c", size = 158229790 },
     { url = "https://files.pythonhosted.org/packages/9f/81/baba53585da791d043c10084cf9553e074548408e04ae884cfe9193bd484/nvidia_cusolver_cu12-11.7.1.2-py3-none-manylinux2014_x86_64.whl", hash = "sha256:6cf28f17f64107a0c4d7802be5ff5537b2130bfc112f25d5a30df227058ca0e6", size = 158229780 },
+    { url = "https://files.pythonhosted.org/packages/7c/5f/07d0ba3b7f19be5a5ec32a8679fc9384cfd9fc6c869825e93be9f28d6690/nvidia_cusolver_cu12-11.7.1.2-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:dbbe4fc38ec1289c7e5230e16248365e375c3673c9c8bac5796e2e20db07f56e", size = 157833630 },
     { url = "https://files.pythonhosted.org/packages/d4/53/fff50a0808df7113d77e3bbc7c2b7eaed6f57d5eb80fbe93ead2aea1e09a/nvidia_cusolver_cu12-11.7.1.2-py3-none-win_amd64.whl", hash = "sha256:6813f9d8073f555444a8705f3ab0296d3e1cb37a16d694c5fc8b862a0d8706d7", size = 149287877 },
 ]
 
@@ -741,7 +749,9 @@ dependencies = [
     { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/eb/6681efd0aa7df96b4f8067b3ce7246833dd36830bb4cec8896182773db7d/nvidia_cusparse_cu12-12.5.4.2-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d25b62fb18751758fe3c93a4a08eff08effedfe4edf1c6bb5afd0890fe88f887", size = 216451147 },
     { url = "https://files.pythonhosted.org/packages/d3/56/3af21e43014eb40134dea004e8d0f1ef19d9596a39e4d497d5a7de01669f/nvidia_cusparse_cu12-12.5.4.2-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7aa32fa5470cf754f72d1116c7cbc300b4e638d3ae5304cfa4a638a5b87161b1", size = 216451135 },
+    { url = "https://files.pythonhosted.org/packages/06/1e/b8b7c2f4099a37b96af5c9bb158632ea9e5d9d27d7391d7eb8fc45236674/nvidia_cusparse_cu12-12.5.4.2-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7556d9eca156e18184b94947ade0fba5bb47d69cec46bf8660fd2c71a4b48b73", size = 216561367 },
     { url = "https://files.pythonhosted.org/packages/43/ac/64c4316ba163e8217a99680c7605f779accffc6a4bcd0c778c12948d3707/nvidia_cusparse_cu12-12.5.4.2-py3-none-manylinux2014_x86_64.whl", hash = "sha256:23749a6571191a215cb74d1cdbff4a86e7b19f1200c071b3fcf844a5bea23a2f", size = 216561357 },
     { url = "https://files.pythonhosted.org/packages/45/ef/876ad8e4260e1128e6d4aac803d9d51baf3791ebdb4a9b8d9b8db032b4b0/nvidia_cusparse_cu12-12.5.4.2-py3-none-win_amd64.whl", hash = "sha256:4acb8c08855a26d737398cba8fb6f8f5045d93f82612b4cfd84645a2332ccf20", size = 213712630 },
 ]
@@ -784,6 +794,7 @@ dependencies = [
     { name = "pytest" },
     { name = "ruff" },
     { name = "sentencepiece" },
+    { name = "tqdm" },
     { name = "typing-extensions" },
     { name = "tyro" },
 ]
@@ -804,6 +815,7 @@ requires-dist = [
     { name = "pytest", specifier = ">=8.3.3" },
     { name = "ruff", specifier = ">=0.7.1" },
     { name = "sentencepiece", specifier = ">=0.2.0" },
+    { name = "tqdm" },
     { name = "typing-extensions", specifier = ">=4.12.2" },
     { name = "tyro", specifier = ">=0.8.14" },
 ]
@@ -936,8 +948,6 @@ version = "6.1.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/26/10/2a30b13c61e7cf937f4adf90710776b7918ed0a9c434e2c38224732af310/psutil-6.1.0.tar.gz", hash = "sha256:353815f59a7f64cdaca1c0307ee13558a0512f6db064e92fe833784f08539c7a", size = 508565 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/2b/f4dea5d993d9cd22ad958eea828a41d5d225556123d372f02547c29c4f97/psutil-6.1.0-cp27-none-win32.whl", hash = "sha256:9118f27452b70bb1d9ab3198c1f626c2499384935aaf55388211ad982611407e", size = 246648 },
-    { url = "https://files.pythonhosted.org/packages/9f/14/4aa97a7f2e0ac33a050d990ab31686d651ae4ef8c86661fef067f00437b9/psutil-6.1.0-cp27-none-win_amd64.whl", hash = "sha256:a8506f6119cff7015678e2bce904a4da21025cc70ad283a53b099e7620061d85", size = 249905 },
     { url = "https://files.pythonhosted.org/packages/01/9e/8be43078a171381953cfee33c07c0d628594b5dbfc5157847b85022c2c1b/psutil-6.1.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:6e2dcd475ce8b80522e51d923d10c7871e45f20918e027ab682f94f1c6351688", size = 247762 },
     { url = "https://files.pythonhosted.org/packages/1d/cb/313e80644ea407f04f6602a9e23096540d9dc1878755f3952ea8d3d104be/psutil-6.1.0-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:0895b8414afafc526712c498bd9de2b063deaac4021a3b3c34566283464aff8e", size = 248777 },
     { url = "https://files.pythonhosted.org/packages/65/8e/bcbe2025c587b5d703369b6a75b65d41d1367553da6e3f788aff91eaf5bd/psutil-6.1.0-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9dcbfce5d89f1d1f2546a2090f4fcf87c7f669d1d90aacb7d7582addece9fb38", size = 284259 },
@@ -1302,6 +1312,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/94/d4/f8ac1f5bd22c15fad3b527e025ce219bd526acdbd903f52053df2baecc8b/tornado-6.4.1-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a02a08cc7a9314b006f653ce40483b9b3c12cda222d6a46d4ac63bb6c9057698", size = 436882 },
     { url = "https://files.pythonhosted.org/packages/4b/3e/a8124c21cc0bbf144d7903d2a0cadab15cadaf683fa39a0f92bc567f0d4d/tornado-6.4.1-cp38-abi3-win32.whl", hash = "sha256:d9a566c40b89757c9aa8e6f032bcdb8ca8795d7c1a9762910c722b1635c9de4d", size = 438092 },
     { url = "https://files.pythonhosted.org/packages/d9/2f/3f2f05e84a7aff787a96d5fb06821323feb370fe0baed4db6ea7b1088f32/tornado-6.4.1-cp38-abi3-win_amd64.whl", hash = "sha256:b24b8982ed444378d7f21d563f4180a2de31ced9d8d84443907a0a64da2072e7", size = 438532 },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "platform_system == 'Windows'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e8/4f/0153c21dc5779a49a0598c445b1978126b1344bab9ee71e53e44877e14e0/tqdm-4.67.0.tar.gz", hash = "sha256:fe5a6f95e6fe0b9755e9469b77b9c3cf850048224ecaa8293d7d2d31f97d869a", size = 169739 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/78/57043611a16c655c8350b4c01b8d6abfb38cc2acb475238b62c2146186d7/tqdm-4.67.0-py3-none-any.whl", hash = "sha256:0cd8af9d56911acab92182e88d763100d4788bdf421d251616040cc4d44863be", size = 78590 },
 ]
 
 [[package]]


### PR DESCRIPTION
1. adding clu (and it comes with tensorflow unfortunately). also we shouldn't use numpy 2 just yet
2. added training script (only data parallel) with 
    a. stock flax train state instead of our train state
    b. stock optax transformation instead of custom one (we dropped support for providing `eval_params`)
    c. new orbax api on saving with args instead of using checkpointer
    d. faked but still sharded data loaders
    e. clu for metrics writing (still missing validation & data iterator atm)
3. `Config` and related optimizer and lr schedule classes are expected to move around once we have a config system for opensource project.
4. worked on both gpu and tpu

gpu:

```
05:44:32.188 [I] Setting work unit notes: 2.3 steps/s, 0.1% (1831/2000000), ETA: 10d1h35m (6m : 0.0% next_batch, 99.5% train_step, 0.0% write_scalars) (3348320:local.py:41)
INFO:absl:[1831] steps_per_sec=2.29745
05:44:32.188 [I] [1831] steps_per_sec=2.29745                                                     (3348320:logging_writer.py:48)
INFO:absl:[1831] uptime=395.301
05:44:32.188 [I] [1831] uptime=395.301                                                            (3348320:logging_writer.py:48)
INFO:absl:[1900] grad_norm=1.302665114402771, loss=0.8210251927375793, param_norm=477.3653869628906
```

tpu:

```
INFO:absl:Setting work unit notes: 2.2 steps/s, 0.0% (241/2000000), ETA: 10d11h40m (2m : 2.8% next_batch, 90.6% train_step, 0.1% write_scalars)
06:35:31.384 [I] Setting work unit notes: 2.2 steps/s, 0.0% (241/2000000), ETA: 10d11h40m (2m : 2.8% next_batch, 90.6% train_step, 0.1% write_scalars) (31014:local.py:41)
INFO:absl:[241] steps_per_sec=2.20724
06:35:31.384 [I] [241] steps_per_sec=2.20724                                                      (31014:logging_writer.py:48)
INFO:absl:[241] uptime=178.963
06:35:31.385 [I] [241] uptime=178.963                                                             (31014:logging_writer.py:48)
INFO:absl:[300] grad_norm=11.3125, loss=2.0212149620056152, param_norm=476
06:35:58.094 [I] [300] grad_norm=11.3125, loss=2.0212149620056152, param_norm=476                 (31014:logging_writer.py:48)
```