### PR TITLE
Relax the numpy version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,7 @@ dependencies = [
     "ipykernel>=6.29.5",
     "jax[cuda12]==0.4.34",
     "jaxtyping==0.2.34",
-    # TODO: Upgrade to 2.1.2 once we have an alternative to pickle for data serialization.
-    "numpy==1.26.4",
+    "numpy>=1.26.4",
     "opencv-python>=4.10.0.84",
     "openpi-client",
     "orbax-checkpoint==0.7.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2434,7 +2434,7 @@ requires-dist = [
     { name = "jaxtyping", specifier = "==0.2.34" },
     { name = "lerobot", git = "https://github.com/huggingface/lerobot" },
     { name = "ml-collections", specifier = "==1.0.0" },
-    { name = "numpy", specifier = "==1.26.4" },
+    { name = "numpy", specifier = ">=1.26.4" },
     { name = "opencv-python", specifier = ">=4.10.0.84" },
     { name = "openpi-client", editable = "packages/openpi-client" },
     { name = "orbax-checkpoint", specifier = "==0.7.0" },


### PR DESCRIPTION
We can't bump to 2.0.0 because of LeRobot.