### PR TITLE
Checkpoint downloading fixes

### DIFF
--- a/scripts/serve_policy.py
+++ b/scripts/serve_policy.py
@@ -13,7 +13,6 @@ from openpi.policies import libero_policy
 from openpi.policies import policy as _policy
 from openpi.policies import policy_config as _policy_config
 from openpi.serving import websocket_policy_server
-from openpi.shared import download
 from openpi.training import config as _config
 
 
@@ -50,14 +49,13 @@ def create_default_policy(env: EnvMode, default_prompt: str | None) -> _policy.P
     match env:
         case EnvMode.ALOHA:
             logging.info("Loading model...")
-            ckpt_path = download.download_openpi("s3://openpi-assets-internal/checkpoints/pi0_real/model")
-            model = _exported.PiModel.from_checkpoint(ckpt_path)
+            model = _exported.PiModel.from_checkpoint("s3://openpi-assets-internal/checkpoints/pi0_real/model")
 
             logging.info("Creating policy...")
             delta_action_mask = _policy_config.make_bool_mask(6, -1, 6, -1)
             config = _policy_config.PolicyConfig(
                 model=model,
-                norm_stats=_exported.import_norm_stats(ckpt_path, "trossen_biarm_single_base_cam_24dim"),
+                norm_stats=model.norm_stats("trossen_biarm_single_base_cam_24dim"),
                 default_prompt=default_prompt,
                 input_layers=[
                     aloha_policy.ActInputsRepack(),
@@ -77,13 +75,12 @@ def create_default_policy(env: EnvMode, default_prompt: str | None) -> _policy.P
             )
         case EnvMode.ALOHA_SIM:
             logging.info("Loading model...")
-            ckpt_path = download.download_openpi("s3://openpi-assets-internal/checkpoints/pi0_sim/model")
-            model = _exported.PiModel.from_checkpoint(ckpt_path)
+            model = _exported.PiModel.from_checkpoint("s3://openpi-assets-internal/checkpoints/pi0_sim/model")
 
             logging.info("Creating policy...")
             config = _policy_config.PolicyConfig(
                 model=model,
-                norm_stats=_exported.import_norm_stats(ckpt_path, "huggingface_aloha_sim_transfer_cube"),
+                norm_stats=model.norm_stats("huggingface_aloha_sim_transfer_cube"),
                 default_prompt=default_prompt,
                 input_layers=[
                     aloha_policy.ActInputsRepack(),
@@ -103,15 +100,14 @@ def create_default_policy(env: EnvMode, default_prompt: str | None) -> _policy.P
             )
         case EnvMode.DROID:
             logging.info("Loading model...")
-            ckpt_path = download.download_openpi(
+            model = _exported.PiModel.from_checkpoint(
                 "s3://openpi-assets-internal/checkpoints/gemmamix_nov4_droid_no22_1056am/290000/model"
             )
-            model = _exported.PiModel.from_checkpoint(ckpt_path)
 
             logging.info("Creating policy...")
             config = _policy_config.PolicyConfig(
                 model=model,
-                norm_stats=_exported.import_norm_stats(ckpt_path, "openx_droid"),
+                norm_stats=model.norm_stats("openx_droid"),
                 default_prompt=default_prompt,
                 input_layers=[
                     droid_policy.DroidInputs(
@@ -129,15 +125,14 @@ def create_default_policy(env: EnvMode, default_prompt: str | None) -> _policy.P
             )
         case EnvMode.CALVIN:
             logging.info("Loading model...")
-            ckpt_path = download.download_openpi(
+            model = _exported.PiModel.from_checkpoint(
                 "s3://openpi-assets-internal/checkpoints/release_gemmamix_calvin_nov24_2053/40000/model"
             )
-            model = _exported.PiModel.from_checkpoint(ckpt_path)
 
             logging.info("Creating policy...")
             config = _policy_config.PolicyConfig(
                 model=model,
-                norm_stats=_exported.import_norm_stats(ckpt_path, "calvin"),
+                norm_stats=model.norm_stats("calvin"),
                 default_prompt=default_prompt,
                 input_layers=[
                     calvin_policy.CalvinInputs(action_dim=model.action_dim),
@@ -149,15 +144,14 @@ def create_default_policy(env: EnvMode, default_prompt: str | None) -> _policy.P
             )
         case EnvMode.LIBERO:
             logging.info("Loading model...")
-            ckpt_path = download.download_openpi(
+            model = _exported.PiModel.from_checkpoint(
                 "s3://openpi-assets-internal/checkpoints/release_gemmamix_libero_nov23_1443/40000/model"
             )
-            model = _exported.PiModel.from_checkpoint(ckpt_path)
 
             logging.info("Creating policy...")
             config = _policy_config.PolicyConfig(
                 model=model,
-                norm_stats=_exported.import_norm_stats(ckpt_path, "libero"),
+                norm_stats=model.norm_stats("libero"),
                 default_prompt=default_prompt,
                 input_layers=[
                     libero_policy.LiberoInputs(action_dim=model.action_dim),

--- a/src/openpi/models/exported_test.py
+++ b/src/openpi/models/exported_test.py
@@ -5,21 +5,27 @@ from openpi.models import pi0
 
 
 def test_sample_actions():
-    model = exported.PiModel.from_checkpoint("checkpoints/pi0_sim/model")
+    model = exported.PiModel.from_checkpoint("s3://openpi-assets-internal/checkpoints/pi0_sim/model")
     actions = model.sample_actions(jax.random.key(0), model.fake_obs(), num_steps=10)
 
     assert actions.shape == (1, model.action_horizon, model.action_dim)
 
 
 def test_exported_as_pi0():
-    model = exported.model_from_checkpoint(pi0.Module(), "checkpoints/pi0_sim/model", param_path="decoder")
+    model = exported.model_from_checkpoint(
+        pi0.Module(),
+        "s3://openpi-assets-internal/checkpoints/pi0_sim/model",
+        param_path="decoder",
+    )
     actions = model.sample_actions(jax.random.key(0), model.fake_obs(), num_steps=10)
 
     assert actions.shape == (1, model.action_horizon, model.action_dim)
 
 
 def test_exported_droid():
-    model = exported.PiModel.from_checkpoint("checkpoints/gemmamix_dct_dec5_droid_dec8_1008am/340000/model")
+    model = exported.PiModel.from_checkpoint(
+        "s3://openpi-assets-internal/checkpoints/gemmamix_dct_dec5_droid_dec8_1008am/340000/model"
+    )
     actions = model.sample_actions(jax.random.key(0), model.fake_obs(), num_denoising_steps=10)
 
     assert actions.shape == (1, model.action_horizon, model.action_dim)

--- a/src/openpi/models/tokenizer.py
+++ b/src/openpi/models/tokenizer.py
@@ -1,10 +1,10 @@
 import abc
-import os
 
-import fsspec
 import numpy as np
 import sentencepiece
 from typing_extensions import override
+
+import openpi.shared.download as download
 
 
 class Tokenizer(abc.ABC):
@@ -24,12 +24,8 @@ class PaligemmaTokenizer(Tokenizer):
     def __init__(self, max_len: int = 48):
         self._max_len = max_len
 
-        cache_path = os.path.expanduser("~/.cache/openpi/paligemma_tokenizer.model")  # noqa: PTH111
-        with fsspec.open(
-            "filecache::gs://big_vision/paligemma_tokenizer.model",
-            gs={"token": "anon"},
-            filecache={"cache_storage": cache_path},
-        ) as f:
+        path = download.download("gs://big_vision/paligemma_tokenizer.model", gs={"token": "anon"})
+        with path.open("rb") as f:
             self._tokenizer = sentencepiece.SentencePieceProcessor(model_proto=f.read())
 
     @override

--- a/src/openpi/policies/policy_test.py
+++ b/src/openpi/policies/policy_test.py
@@ -19,13 +19,12 @@ def test_infer():
 
 
 def test_exported_aloha_sim():
-    ckpt_path = "checkpoints/pi0_sim/model"
-    model = _exported.PiModel.from_checkpoint(ckpt_path)
+    model = _exported.PiModel.from_checkpoint("s3://openpi-assets-internal/checkpoints/pi0_sim/model")
 
     policy = aloha_policy.create_aloha_policy(
         model,
         aloha_policy.PolicyConfig(
-            norm_stats=_exported.import_norm_stats(ckpt_path, "huggingface_aloha_sim_transfer_cube"),
+            norm_stats=model.norm_stats("huggingface_aloha_sim_transfer_cube"),
             adapt_to_pi=False,
         ),
     )

--- a/src/openpi/shared/download.py
+++ b/src/openpi/shared/download.py
@@ -1,10 +1,12 @@
 import concurrent.futures
+import getpass
 import logging
 import os
 import pathlib
+import shutil
 import stat
 import time
-from urllib.parse import urlparse
+import urllib.parse
 
 import boto3
 import boto3.s3.transfer as s3_transfer
@@ -20,66 +22,109 @@ from types_boto3_s3.service_resource import ObjectSummary
 _OPENPI_DATA_HOME = "OPENPI_DATA_HOME"
 
 
-def is_openpi_url(url: str) -> bool:
-    """Check if the url is an OpenPI S3 bucket url."""
-    return url.startswith("s3://openpi-assets")
+def get_cache_dir() -> pathlib.Path:
+    default_dir = "~/.cache/openpi"
+    if os.path.exists("/mnt/weka"):  # noqa: PTH110
+        default_dir = f"/mnt/weka/{getpass.getuser()}/.cache/openpi"
+
+    cache_dir = pathlib.Path(os.getenv(_OPENPI_DATA_HOME, default_dir)).expanduser().resolve()
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    _set_folder_permission(cache_dir)
+    return cache_dir
 
 
 def download(url: str, **kwargs) -> pathlib.Path:
-    """Download a file from a remote filesystem to the local cache, and return the local path."""
-    cache_dir = _cache_dir()
-    fs, path = fsspec.core.url_to_fs(url, **kwargs)
-    if not fs.exists(path):
-        raise FileNotFoundError(f"File not found at {url}")
-    protocol_str = fs.protocol[0] if isinstance(fs.protocol, tuple) else fs.protocol
-    local_path = cache_dir / protocol_str / path
+    """Download a file or directoryfrom a remote filesystem to the local cache, and return the local path.
+
+    It is safe to call this function concurrently from multiple processes.
+    See `get_cache_dir` for more details on the cache directory.
+
+    Args:
+        url: URL to the file to download.
+        **kwargs: Additional arguments to pass to fsspec.
+
+    Returns:
+        Local path to the downloaded file or directory. That path is guaranteed to exist and is absolute.
+    """
+    # Don't use fsspec to parse the url to avoid unnecessary connection to the remote filesystem.
+    parsed = urllib.parse.urlparse(url)
+
+    # Short circuit if this is a local path.
+    if parsed.scheme == "":
+        path = pathlib.Path(url)
+        if not path.exists():
+            raise FileNotFoundError(f"File not found at {url}")
+        return path
+
+    local_path = get_cache_dir() / parsed.netloc / parsed.path.strip("/")
+    local_path = local_path.resolve()
+
+    # Check if file already exists in cache.
     if local_path.exists():
         return local_path
 
-    total_size = fs.du(url)
-    with (
-        tqdm.tqdm(
-            total=total_size, desc=f"Downloading {url} to {local_path}", unit="B", unit_scale=True, unit_divisor=1024
-        ) as pbar,
-        filelock.FileLock(local_path / ".lock"),
-    ):
+    # Download file from remote file system.
+    print(f"Downloading {url} to {local_path}")
+    with filelock.FileLock(local_path.with_suffix(".lock")):
+        scratch_path = local_path.with_suffix(".partial")
+
+        if _is_openpi_url(url):
+            _download_boto3(url, scratch_path)
+        else:
+            _download_fsspec(url, scratch_path, **kwargs)
+
+        shutil.move(scratch_path, local_path)
+        _ensure_permissions(local_path)
+
+    return local_path
+
+
+def _download_fsspec(url: str, local_path: pathlib.Path, **kwargs) -> None:
+    """Download a file from a remote filesystem to the local cache, and return the local path."""
+    fs, _ = fsspec.core.url_to_fs(url, **kwargs)
+    info = fs.info(url)
+    if is_dir := (info["type"] == "directory"):  # noqa: SIM108
+        total_size = fs.du(url)
+    else:
+        total_size = info["size"]
+    with tqdm.tqdm(total=total_size, unit="B", unit_scale=True, unit_divisor=1024) as pbar:
         executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-        future = executor.submit(fs.get, url, local_path, recursive=True)
+        future = executor.submit(fs.get, url, local_path, recursive=is_dir)
         while not future.done():
             current_size = sum(f.stat().st_size for f in [*local_path.rglob("*"), local_path] if f.is_file())
             pbar.update(current_size - pbar.n)
             time.sleep(1)
         pbar.update(total_size - pbar.n)
-    _ensure_permissions(local_path)
-    return local_path
 
 
-def download_openpi(url: str, *, boto_session: boto3.Session = None, workers: int = 20) -> pathlib.Path:
+def _download_boto3(
+    url: str,
+    local_path: pathlib.Path,
+    *,
+    boto_session: boto3.Session | None = None,
+    workers: int = 20,
+) -> None:
     """Download a file from the OpenPI S3 bucket using boto3. This is a more performant version of download but can
     only handle s3 urls. In openpi repo, this is mainly used to access assets in S3 with higher throughput.
 
     Input:
         url: URL to openpi checkpoint path.
+        local_path: local path to the downloaded file.
         boto_session: Optional boto3 session, will create by default if not provided.
         workers: number of workers for downloading.
-    Output:
-        pathlib.Path: local path to the downloaded file.
     """
 
     def validate_and_parse_url(maybe_s3_url: str) -> tuple[str, str]:
-        parsed = urlparse(maybe_s3_url)
+        parsed = urllib.parse.urlparse(maybe_s3_url)
         if parsed.scheme != "s3":
             raise ValueError(f"URL must be an S3 URL (s3://), got: {maybe_s3_url}")
         bucket_name = parsed.netloc
         prefix = parsed.path.strip("/")
         return bucket_name, prefix
 
-    cache_dir = _cache_dir()
     bucket_name, prefix = validate_and_parse_url(url)
     s3api = boto3.resource("s3")
     bucket = s3api.Bucket(bucket_name)
-    return_dir = cache_dir / prefix
-    return_dir.mkdir(parents=True, exist_ok=True)
 
     objects = list(bucket.objects.filter(Prefix=prefix))
     total_size = sum(obj.size for obj in objects)
@@ -88,48 +133,35 @@ def download_openpi(url: str, *, boto_session: boto3.Session = None, workers: in
     s3t = _get_s3_transfer_manager(session, workers)
 
     def transfer(
-        s3obj: ObjectSummary, local_path: pathlib.Path, progress_func
+        s3obj: ObjectSummary, dest_path: pathlib.Path, progress_func
     ) -> s3_transfer_futures.TransferFuture | None:
-        if local_path.exists():
-            local_stat = local_path.stat()
-            if s3obj.size == local_stat.st_size:
+        if dest_path.exists():
+            dest_stat = dest_path.stat()
+            if s3obj.size == dest_stat.st_size:
                 progress_func(s3obj.size)
                 return None
-        local_path.parent.mkdir(parents=True, exist_ok=True)
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
         return s3t.download(
             bucket_name,
             s3obj.key,
-            str(local_path),
+            str(dest_path),
             subscribers=[
                 s3_transfer.ProgressCallbackInvoker(progress_func),
             ],
         )
 
     try:
-        with (
-            tqdm.tqdm(
-                total=total_size,
-                desc=f"Downloading {url} to {return_dir}",
-                unit="B",
-                unit_scale=True,
-                unit_divisor=1024,
-            ) as pbar,
-            filelock.FileLock(return_dir / ".lock"),
-        ):
+        with tqdm.tqdm(total=total_size, unit="B", unit_scale=True, unit_divisor=1024) as pbar:
             futures = []
             for obj in objects:
                 relative_path = pathlib.Path(obj.key).relative_to(prefix)
-                local_path = return_dir / relative_path
-                if future := transfer(obj, local_path, pbar.update):
+                dest_path = local_path / relative_path
+                if future := transfer(obj, dest_path, pbar.update):
                     futures.append(future)
-                # S3 TransferFuture is not a concurrent.futures.Future, so we need to manually call result()
-                # to wait for futures.
-                for future in futures:
-                    future.result()
+            for future in futures:
+                future.result()
     finally:
         s3t.shutdown()
-    _ensure_permissions(return_dir)
-    return return_dir
 
 
 def _get_s3_transfer_manager(session: boto3.Session, workers: int) -> s3_transfer.TransferManager:
@@ -156,20 +188,13 @@ def _set_folder_permission(folder_path: pathlib.Path) -> None:
     _set_permission(folder_path, stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO)
 
 
-def _cache_dir() -> pathlib.Path:
-    cache_dir = pathlib.Path(os.getenv(_OPENPI_DATA_HOME, "~/.cache/openpi")).expanduser().resolve()
-    cache_dir.mkdir(parents=True, exist_ok=True)
-    _set_folder_permission(cache_dir)
-    return cache_dir
-
-
 def _ensure_permissions(path: pathlib.Path) -> None:
     """Since we are sharing cache directory with containerized runtime as well as training script, we need to
     ensure that the cache directory has the correct permissions.
     """
 
     def _setup_folder_permission_between_cache_dir_and_path(path: pathlib.Path) -> None:
-        cache_dir = _cache_dir()
+        cache_dir = get_cache_dir()
         relative_path = path.relative_to(cache_dir)
         moving_path = cache_dir
         for part in relative_path.parts:
@@ -194,3 +219,8 @@ def _ensure_permissions(path: pathlib.Path) -> None:
         for dir in dirs:
             dir_path = root_path / dir
             _set_folder_permission(dir_path)
+
+
+def _is_openpi_url(url: str) -> bool:
+    """Check if the url is an OpenPI S3 bucket url."""
+    return url.startswith("s3://openpi-assets")

--- a/src/openpi/shared/download_test.py
+++ b/src/openpi/shared/download_test.py
@@ -1,0 +1,36 @@
+import pathlib
+
+import pytest
+
+import openpi.shared.download as download
+
+
+def test_download_local(tmp_path: pathlib.Path):
+    local_path = tmp_path / "local"
+    local_path.touch()
+
+    result = download.download(str(local_path))
+    assert result == local_path
+
+    with pytest.raises(FileNotFoundError):
+        download.download("bogus")
+
+
+def test_download_s3():
+    remote_path = "s3://openpi-assets-internal/checkpoints/pi0_base"
+
+    local_path = download.download(remote_path)
+    assert local_path.exists()
+
+    new_local_path = download.download(remote_path)
+    assert new_local_path == local_path
+
+
+def test_download_fsspec():
+    remote_path = "gs://big_vision/paligemma_tokenizer.model"
+
+    local_path = download.download(remote_path, gs={"token": "anon"})
+    assert local_path.exists()
+
+    new_local_path = download.download(remote_path, gs={"token": "anon"})
+    assert new_local_path == local_path

--- a/src/openpi/training/config.py
+++ b/src/openpi/training/config.py
@@ -1,8 +1,6 @@
 from collections.abc import Sequence
 import dataclasses
 import difflib
-import getpass
-import os
 import pathlib
 from typing import Annotated, Any, Protocol, Union
 
@@ -13,18 +11,17 @@ import openpi.models.model as _model
 import openpi.models.pi0 as pi0
 import openpi.models.pi0_small as pi0_small
 import openpi.models.tokenizer as _tokenizer
-from openpi.policies import aloha_policy
+import openpi.policies.aloha_policy as aloha_policy
+import openpi.shared.download as download
 import openpi.shared.normalize as _normalize
 import openpi.training.optimizer as _optimizer
 import openpi.training.weight_loaders as weight_loaders
 import openpi.transforms as _transforms
 
 
-def default_dataset_root() -> str | None:
-    # TODO(ury): Temporary, remove this once the default works well.
-    if os.path.exists("/mnt/weka"):  # noqa: PTH110
-        return f"/mnt/weka/{getpass.getuser()}/.cache/lerobot"
-    return None
+def default_dataset_root() -> str:
+    """Default location for the dataset cache."""
+    return str(download.get_cache_dir() / "datasets")
 
 
 @dataclasses.dataclass
@@ -44,7 +41,6 @@ class DataConfig:
     model_transforms: _transforms.Group = dataclasses.field(default_factory=_transforms.Group)
 
     # Indicates where the cached dataset should be stored.
-    # This can also be controlled by setting the LEROBOT_HOME environment variable.
     dataset_root: str | None = dataclasses.field(default_factory=default_dataset_root)
 
 

--- a/src/openpi/training/weight_loaders.py
+++ b/src/openpi/training/weight_loaders.py
@@ -11,8 +11,8 @@ import numpy as np
 import scipy.ndimage
 
 import openpi.models.model as _model
-from openpi.shared import download
 import openpi.shared.array_typing as at
+import openpi.shared.download as download
 
 logger = logging.getLogger(__name__)
 
@@ -32,11 +32,7 @@ class CheckpointWeightLoader(WeightLoader):
     ckpt_path: str
 
     def load(self, params: at.Params) -> at.Params:
-        if download.is_openpi_url(self.ckpt_path):
-            path = download.download_openpi(self.ckpt_path)
-        else:
-            path = download.download(self.ckpt_path)
-        return _model.restore_params(path)
+        return _model.restore_params(download.download(self.ckpt_path))
 
 
 def _recover_tree(d: dict) -> dict:


### PR DESCRIPTION
The change makes a bunch of improvements to the downloading functionality:

- The file lock will now guarantee that only one process will download the files.
- Stopping downloading in the middle will not corrupt the cache state and can be resumed.
- We communicate with the remote bucket only after confirming that we don't have the local cache.
- Ge fsspec path can now also support downloading individual files when there are no list bucket permissions.