### PR TITLE
code for fsdp

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -21,6 +21,7 @@ import openpi.training.checkpoints as _checkpoints
 import openpi.training.config as _config
 import openpi.training.data_loader as _data_loader
 import openpi.training.optimizer as _optimizer
+import openpi.training.sharding as sharding
 import openpi.training.utils as training_utils
 import openpi.training.weight_loaders as _weight_loaders
 
@@ -99,6 +100,7 @@ def init_train_state(
     init_rng: at.KeyArrayLike,
     batch: tuple[_common.Observation, _common.Actions],
     mesh: jax.sharding.Mesh,
+    data_sharding: jax.sharding.Sharding,
     *,
     resume: bool,
 ) -> tuple[training_utils.TrainState, Any]:
@@ -106,13 +108,27 @@ def init_train_state(
     freeze_mask = None
     tx = _optimizer.create_optimizer(config.optimizer, config.lr_schedule, weight_decay_mask, freeze_mask)
 
-    def init(rng: at.KeyArrayLike, data: tuple[_common.Observation, _common.Actions]) -> training_utils.TrainState:
+    def init(
+        rng: at.KeyArrayLike,
+        data: tuple[_common.Observation, _common.Actions],
+        params_sharding: jax.sharding.Sharding | None = None,
+    ) -> training_utils.TrainState:
         rng, model_rng = jax.random.split(rng)
         observation, actions = data
         params = model.init_params(model_rng, observation, actions)
+        # jax.experimental.io_callback raises spmd partitioning warnings, setting constraints
+        # to replicate params to avoid the warnings. the returned train state will be sharded still
+        # since fsdp sharding is specified as output_sharding when jitting this function.
+        if params_sharding is not None:
+            params = jax.lax.with_sharding_constraint(params, params_sharding)
         params = jax.experimental.io_callback(
-            partial(_load_weights_and_validate, config.weight_loader), params, params, ordered=True
+            partial(_load_weights_and_validate, config.weight_loader),
+            params,
+            params,
+            ordered=True,
         )
+        if params_sharding is not None:
+            params = jax.lax.with_sharding_constraint(params, params_sharding)
         return training_utils.TrainState(
             step=0,
             params=params,
@@ -123,18 +139,19 @@ def init_train_state(
         )
 
     replicated_sharding = jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec())
-    data_parallel_sharding = jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec(("batch",)))
 
     train_state_shape = jax.eval_shape(init, init_rng, batch)
-    # This is where we may want to shard the train state (e.g., FSDP).
-    state_sharding = jax.tree.map(lambda _: replicated_sharding, train_state_shape)
+    state_sharding = sharding.fsdp_sharding(train_state_shape, mesh, log=True)
 
     if resume:
         return train_state_shape, state_sharding
 
     train_state = jax.jit(
-        init, in_shardings=(replicated_sharding, data_parallel_sharding), out_shardings=state_sharding
-    )(init_rng, batch)
+        init,
+        in_shardings=(replicated_sharding, data_sharding),
+        out_shardings=state_sharding,
+        static_argnums=(2,),
+    )(init_rng, batch, replicated_sharding)
     return train_state, state_sharding
 
 
@@ -188,10 +205,13 @@ def main(config: _config.TrainConfig):
     rng = jax.random.key(config.seed)
     train_rng, init_rng = jax.random.split(rng)
 
-    # data parallel only
-    # TODO: replace with jax.make_mesh when available
-    mesh = jax.sharding.Mesh(jax.devices(), ("batch",))
-    data_parallel_sharding = jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec(("batch",)))
+    if jax.device_count() % config.fsdp_devices != 0:
+        raise ValueError(
+            f"Number of devices {jax.device_count()} must be divisible by the number of FSDP devices {config.fsdp_devices}."
+        )
+    mesh_shape = (jax.device_count() // config.fsdp_devices, config.fsdp_devices)
+    mesh = jax.make_mesh(mesh_shape, ("batch", "model"))
+    data_sharding = jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec(("batch", "model")))
     replicated_sharding = jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec())
 
     checkpoint_manager, resuming = _checkpoints.initialize_checkpoint(
@@ -207,7 +227,7 @@ def main(config: _config.TrainConfig):
     data_loader = _data_loader.create_data_loader(
         config,
         model,
-        sharding=data_parallel_sharding,
+        sharding=data_sharding,
         num_workers=config.num_workers,
         shuffle=True,
     )
@@ -215,7 +235,9 @@ def main(config: _config.TrainConfig):
     batch = next(data_iter)
     logging.info(f"Data loader initialized: {training_utils.to_tree_info(batch)}")
 
-    train_state, train_state_sharding = init_train_state(config, model, init_rng, batch, mesh, resume=resuming)
+    train_state, train_state_sharding = init_train_state(
+        config, model, init_rng, batch, mesh, data_sharding, resume=resuming
+    )
     jax.block_until_ready(train_state)
     logging.info(f"Initialized train state:\n{training_utils.to_tree_info(train_state.params)}")
 
@@ -224,7 +246,7 @@ def main(config: _config.TrainConfig):
 
     ptrain_step = jax.jit(
         train_step,
-        in_shardings=(replicated_sharding, train_state_sharding, None, data_parallel_sharding),
+        in_shardings=(replicated_sharding, train_state_sharding, None, data_sharding),
         out_shardings=(train_state_sharding, replicated_sharding),
         donate_argnums=(1,),
     )

--- a/src/openpi/training/config.py
+++ b/src/openpi/training/config.py
@@ -173,6 +173,12 @@ class TrainConfig:
     # If true, will enable wandb logging.
     wandb_enabled: bool = True
 
+    # If the value is greater than 1, FSDP will be enabled and shard across number of specified devices; overall
+    # device memory will be reduced but training could potentially be slower.
+    # eg. if total device is 4 and fsdp devices is 2; then the model will shard to 2 devices and run
+    # data parallel between 2 groups of devices.
+    fsdp_devices: int = 1
+
     @property
     def metadata_dir(self) -> pathlib.Path:
         """Get the metadata directory for this config."""

--- a/src/openpi/training/sharding.py
+++ b/src/openpi/training/sharding.py
@@ -1,0 +1,64 @@
+import logging
+
+import jax
+import numpy as np
+
+
+def fsdp_sharding(
+    pytree,
+    mesh: jax.sharding.Mesh,
+    *,
+    min_size_mbytes: int = 1000,  # 1000 MiB
+    log: bool = False,
+    fsdp_dim_name: str = "model",
+):
+    """Apply FSDP sharding to a pytree of arrays based on the mesh shape.
+
+    Args:
+        pytree: A pytree to be apply sharding specified by the mesh, note that only array types (eg. contains .shape attr)
+          will be considered for sharding.
+        mesh: The mesh being used for applying sharding on to pytree.
+        min_size_mbytes: The minimum size of the array in MiB to be considered for sharding, any array smaller than this
+          will be replicated.
+        log: If true, will log the sharding decisions for arrays that are being considered for sharding.
+        fsdp_dim_name: The name of the dimension to shard on, this is the name of the dimension in the mesh shape. default
+          is "model" which is consistent with the mesh created in the main function.
+
+    Returns:
+        The sharded pytree.
+    """
+    min_size_bytes = min_size_mbytes * 2**20
+
+    def _shard_arr(kp, array: jax.ShapeDtypeStruct):
+        # if fsdp is not actually going to be used, replicate everything to avoid extraneous logging
+        if mesh.shape[fsdp_dim_name] == 1:
+            return jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec())
+        # replicate scalar and vector arrays
+        if not hasattr(array, "shape"):
+            return jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec())
+        if len(array.shape) < 2:
+            return jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec())
+        # replicate small arrays
+        if (arr_size := np.prod(array.shape) * np.dtype(array.dtype).itemsize) < min_size_bytes:
+            return jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec())
+
+        # shard matrices and larger tensors along the largest axis that is divisible by the fsdp dimension
+        axes = np.argsort(array.shape)[::-1]
+        spec = [None] * len(axes)
+        for i in axes:
+            if array.shape[i] % mesh.shape[fsdp_dim_name] == 0:
+                if log:
+                    logging.info(
+                        f"Sharding {jax.tree_util.keystr(kp)} of shape {array.shape} ({arr_size / 2**20:.2f} MiB) along axis {i}"
+                    )
+                spec[i] = fsdp_dim_name
+                return jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec(*spec))
+
+        # replicate if no valid sharding was found
+        if log:
+            logging.warning(
+                f"Could not find a valid sharding for {jax.tree_util.keystr(kp)} of shape {array.shape} with mesh of shape {mesh.shape}"
+            )
+        return jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec())
+
+    return jax.tree_util.tree_map_with_path(_shard_arr, pytree)


### PR DESCRIPTION
replicate https://github.com/Physical-Intelligence/monopi/pull/3092 to openpi

validated 4 gpu can fit batch size of 512 but the speed is slower compares to what we see in monopi (that i will look into separately). in monopi batch size of 384 can run at `4s/step`.

there is a spmd warning on weight reloading io callback and this is due to we are not passing sharding in `jax.experimental.io_callback` but also getting the sharding inside this function is also tricky. Not sure if using io callback is the best approach for restore & initialization. maybe we should have a function for eval shape and a function for actual init or restore.

```
17:32:05.688 [I] Data loader initialized: [0].images['base_0_rgb']: (512, 224, 224, 3)@float32
[0].images['left_wrist_0_rgb']: (512, 224, 224, 3)@float32
[0].images['right_wrist_0_rgb']: (512, 224, 224, 3)@float32
[0].image_masks['base_0_rgb']: (512,)@bool
[0].image_masks['left_wrist_0_rgb']: (512,)@bool
[0].image_masks['right_wrist_0_rgb']: (512,)@bool
[0].state: (512, 24)@float32
[0].tokenized_prompt: (512, 48)@int32
[0].tokenized_prompt_mask: (512, 48)@int32
[1]: (512, 50, 24)@float32 (2046759:train.py:258)
17:32:06.456 [I] Sharding .params['PaliGemma']['llm']['embedder']['input_embedding'] of shape (257152, 2048) (2009.00 MiB) along axis 0 (2046759:train.py:125)
17:32:06.456 [I] Sharding .params['PaliGemma']['llm']['layers']['mlp']['gating_einsum'] of shape (18, 2, 2048, 16384) (4608.00 MiB) along axis 3 (2046759:train.py:125)
17:32:06.456 [I] Sharding .params['PaliGemma']['llm']['layers']['mlp']['linear'] of shape (18, 16384, 2048) (2304.00 MiB) along axis 1 (2046759:train.py:125)
17:32:06.457 [I] Sharding .opt_state[1][0].mu['PaliGemma']['llm']['embedder']['input_embedding'] of shape (257152, 2048) (2009.00 MiB) along axis 0 (2046759:train.py:125)
17:32:06.457 [I] Sharding .opt_state[1][0].mu['PaliGemma']['llm']['layers']['mlp']['gating_einsum'] of shape (18, 2, 2048, 16384) (4608.00 MiB) along axis 3 (2046759:train.py:125)
17:32:06.457 [I] Sharding .opt_state[1][0].mu['PaliGemma']['llm']['layers']['mlp']['linear'] of shape (18, 16384, 2048) (2304.00 MiB) along axis 1 (2046759:train.py:125)
17:32:06.458 [I] Sharding .opt_state[1][0].nu['PaliGemma']['llm']['embedder']['input_embedding'] of shape (257152, 2048) (2009.00 MiB) along axis 0 (2046759:train.py:125)
17:32:06.458 [I] Sharding .opt_state[1][0].nu['PaliGemma']['llm']['layers']['mlp']['gating_einsum'] of shape (18, 2, 2048, 16384) (4608.00 MiB) along axis 3 (2046759:train.py:125)
17:32:06.458 [I] Sharding .opt_state[1][0].nu['PaliGemma']['llm']['layers']['mlp']['linear'] of shape (18, 16384, 2048) (2304.00 MiB) along axis 1 (2046759:train.py:125)
2024-12-21 17:32:07.608616: E external/xla/xla/service/spmd/spmd_partitioner.cc:613] [spmd] Involuntary full rematerialization. The compiler was not able to go from sharding {devices=[1,1,1,4]<=[4]} to {maximal device=0} without doing a full rematerialization of the tensor for HLO operation: %get-tuple-element = f32[18,2,2048,4096]{3,2,1,0} get-tuple-element((s32[], f32[18,8,256,2048]{3,2,1,0}, f32[18,8,256,1024]{3,2,1,0}, f32[18,2,1,2048,256]{4,3,2,1,0}, f32[18,2,1,1024,256]{4,3,2,1,0}, /*index=5*/f32[18,8,2048,256]{3,2,1,0}, f32[18,8,1024,256]{3,2,1,0}, f32[18,2,2048,4096]{3,2,1,0}, f32[18,4096,2048]{2,1,0}, f32[18,2,1024,4096]{3,2,1,0}, /*index=10*/f32[18,4096,1024]{2,1,0}, f32[18,2048]{1,0}, f32[18,1024]{1,0}, f32[18,2048]{1,0}, f32[18,1024]{1,0}, /*index=15*/u32[18,2]{1,0}) %while), index=7, sharding={devices=[1,1,1,4]<=[4]}, metadata={op_name="jit(init)/jit(main)/Module.compute_loss/Module.forward/Module/while" source_file="/home/haohuanw/openpi/.venv/lib/python3.11/site-packages/flax/core/axes_scan.py" source_line=166}. You probably want to enrich the sharding annotations to prevent this from happening.
2024-12-21 17:32:07.608684: E external/xla/xla/service/spmd/spmd_partitioner.cc:613] [spmd] Involuntary full rematerialization. The compiler was not able to go from sharding {devices=[1,4,1]<=[4]} to {maximal device=0} without doing a full rematerialization of the tensor for HLO operation: %get-tuple-element = f32[18,4096,2048]{2,1,0} get-tuple-element((s32[], f32[18,8,256,2048]{3,2,1,0}, f32[18,8,256,1024]{3,2,1,0}, f32[18,2,1,2048,256]{4,3,2,1,0}, f32[18,2,1,1024,256]{4,3,2,1,0}, /*index=5*/f32[18,8,2048,256]{3,2,1,0}, f32[18,8,1024,256]{3,2,1,0}, f32[18,2,2048,4096]{3,2,1,0}, f32[18,4096,2048]{2,1,0}, f32[18,2,1024,4096]{3,2,1,0}, /*index=10*/f32[18,4096,1024]{2,1,0}, f32[18,2048]{1,0}, f32[18,1024]{1,0}, f32[18,2048]{1,0}, f32[18,1024]{1,0}, /*index=15*/u32[18,2]{1,0}) %while), index=8, sharding={devices=[1,4,1]<=[4]}, metadata={op_name="jit(init)/jit(main)/Module.compute_loss/Module.forward/Module/while" source_file="/home/haohuanw/openpi/.venv/lib/python3.11/site-packages/flax/core/axes_scan.py" source_line=166}. You probably want to enrich the sharding annotations to prevent this from happening.
2024-12-21 17:32:07.609345: E external/xla/xla/service/spmd/spmd_partitioner.cc:613] [spmd] Involuntary full rematerialization. The compiler was not able to go from sharding {maximal device=0} to {devices=[4,1]<=[4]} without doing a full rematerialization of the tensor for HLO operation: %get-tuple-element = f32[257152,2048]{1,0} get-tuple-element((token[], f32[1152]{0}, f32[1152]{0}, f32[27,1152]{1,0}, f32[27,1152]{1,0}, /*index=5*/f32[27,1152]{1,0}, f32[27,1152]{1,0}, f32[27,4304]{1,0}, f32[27,1152,4304]{2,1,0}, f32[27,1152]{1,0}, /*index=10*/f32[27,4304,1152]{2,1,0}, f32[27,16,72]{2,1,0}, f32[27,1152,16,72]{3,2,1,0}, f32[27,1152]{1,0}, f32[27,16,72,1152]{3,2,1,0}, /*index=15*/f32[27,16,72]{2,1,0}, f32[27,1152,16,72]{3,2,1,0}, f32[27,16,72]{2,1,0}, f32[27,1152,16,72]{3,2,1,0}, f32[1152]{0}, /*index=20*/f32[14,14,3,1152]{3,2,1,0}, f32[2048]{0}, f32[1152,2048]{1,0}, f32[1,256,1152]{2,1,0}, f32[257152,2048]{1,0}, /*index=25*/f32[2048]{0}, f32[1024]{0}, f32[18,8,256,2048]{3,2,1,0}, f32[18,8,256,1024]{3,2,1,0}, f32[18,2,1,2048,256]{4,3,2,1,0}, /*index=30*/f32[18,2,1,1024,256]{4,3,2,1,0}, f32[18,8,2048,256]{3,2,1,0}, f32[18,8,1024,256]{3,2,1,0}, f32[18,2,2048,16384]{3,2,1,0}, f32[18,16384,2048]{2,1,0}, /*index=35*/f32[18,2,1024,4096]{3,2,1,0}, f32[18,4096,1024]{2,1,0}, f32[18,2048]{1,0}, f32[18,1024]{1,0}, f32[18,2048]{1,0}, /*index=40*/f32[18,1024]{1,0}, f32[1024]{0}, f32[24,1024]{1,0}, f32[24]{0}, f32[1024,24]{1,0}, /*index=45*/f32[1024]{0}, f32[2048,1024]{1,0}, f32[1024]{0}, f32[1024,1024]{1,0}, f32[1024]{0}, /*index=50*/f32[24,1024]{1,0}) %conditional), index=24, sharding={maximal device=0}, metadata={op_name="jit(init)/jit(main)/io_callback" source_file="/home/haohuanw/openpi/scripts/train.py" source_line=159}. You probably want to enrich the sharding annotations to prevent this from happening.
2024-12-21 17:32:07.609521: E external/xla/xla/service/spmd/spmd_partitioner.cc:613] [spmd] Involuntary full rematerialization. The compiler was not able to go from sharding {maximal device=0} to {devices=[1,1,1,4]<=[4]} without doing a full rematerialization of the tensor for HLO operation: %get-tuple-element = f32[18,2,2048,16384]{3,2,1,0} get-tuple-element((token[], f32[1152]{0}, f32[1152]{0}, f32[27,1152]{1,0}, f32[27,1152]{1,0}, /*index=5*/f32[27,1152]{1,0}, f32[27,1152]{1,0}, f32[27,4304]{1,0}, f32[27,1152,4304]{2,1,0}, f32[27,1152]{1,0}, /*index=10*/f32[27,4304,1152]{2,1,0}, f32[27,16,72]{2,1,0}, f32[27,1152,16,72]{3,2,1,0}, f32[27,1152]{1,0}, f32[27,16,72,1152]{3,2,1,0}, /*index=15*/f32[27,16,72]{2,1,0}, f32[27,1152,16,72]{3,2,1,0}, f32[27,16,72]{2,1,0}, f32[27,1152,16,72]{3,2,1,0}, f32[1152]{0}, /*index=20*/f32[14,14,3,1152]{3,2,1,0}, f32[2048]{0}, f32[1152,2048]{1,0}, f32[1,256,1152]{2,1,0}, f32[257152,2048]{1,0}, /*index=25*/f32[2048]{0}, f32[1024]{0}, f32[18,8,256,2048]{3,2,1,0}, f32[18,8,256,1024]{3,2,1,0}, f32[18,2,1,2048,256]{4,3,2,1,0}, /*index=30*/f32[18,2,1,1024,256]{4,3,2,1,0}, f32[18,8,2048,256]{3,2,1,0}, f32[18,8,1024,256]{3,2,1,0}, f32[18,2,2048,16384]{3,2,1,0}, f32[18,16384,2048]{2,1,0}, /*index=35*/f32[18,2,1024,4096]{3,2,1,0}, f32[18,4096,1024]{2,1,0}, f32[18,2048]{1,0}, f32[18,1024]{1,0}, f32[18,2048]{1,0}, /*index=40*/f32[18,1024]{1,0}, f32[1024]{0}, f32[24,1024]{1,0}, f32[24]{0}, f32[1024,24]{1,0}, /*index=45*/f32[1024]{0}, f32[2048,1024]{1,0}, f32[1024]{0}, f32[1024,1024]{1,0}, f32[1024]{0}, /*index=50*/f32[24,1024]{1,0}) %conditional), index=33, sharding={maximal device=0}, metadata={op_name="jit(init)/jit(main)/io_callback" source_file="/home/haohuanw/openpi/scripts/train.py" source_line=159}. You probably want to enrich the sharding annotations to prevent this from happening.
2024-12-21 17:32:07.609564: E external/xla/xla/service/spmd/spmd_partitioner.cc:613] [spmd] Involuntary full rematerialization. The compiler was not able to go from sharding {maximal device=0} to {devices=[1,4,1]<=[4]} without doing a full rematerialization of the tensor for HLO operation: %get-tuple-element = f32[18,16384,2048]{2,1,0} get-tuple-element((token[], f32[1152]{0}, f32[1152]{0}, f32[27,1152]{1,0}, f32[27,1152]{1,0}, /*index=5*/f32[27,1152]{1,0}, f32[27,1152]{1,0}, f32[27,4304]{1,0}, f32[27,1152,4304]{2,1,0}, f32[27,1152]{1,0}, /*index=10*/f32[27,4304,1152]{2,1,0}, f32[27,16,72]{2,1,0}, f32[27,1152,16,72]{3,2,1,0}, f32[27,1152]{1,0}, f32[27,16,72,1152]{3,2,1,0}, /*index=15*/f32[27,16,72]{2,1,0}, f32[27,1152,16,72]{3,2,1,0}, f32[27,16,72]{2,1,0}, f32[27,1152,16,72]{3,2,1,0}, f32[1152]{0}, /*index=20*/f32[14,14,3,1152]{3,2,1,0}, f32[2048]{0}, f32[1152,2048]{1,0}, f32[1,256,1152]{2,1,0}, f32[257152,2048]{1,0}, /*index=25*/f32[2048]{0}, f32[1024]{0}, f32[18,8,256,2048]{3,2,1,0}, f32[18,8,256,1024]{3,2,1,0}, f32[18,2,1,2048,256]{4,3,2,1,0}, /*index=30*/f32[18,2,1,1024,256]{4,3,2,1,0}, f32[18,8,2048,256]{3,2,1,0}, f32[18,8,1024,256]{3,2,1,0}, f32[18,2,2048,16384]{3,2,1,0}, f32[18,16384,2048]{2,1,0}, /*index=35*/f32[18,2,1024,4096]{3,2,1,0}, f32[18,4096,1024]{2,1,0}, f32[18,2048]{1,0}, f32[18,1024]{1,0}, f32[18,2048]{1,0}, /*index=40*/f32[18,1024]{1,0}, f32[1024]{0}, f32[24,1024]{1,0}, f32[24]{0}, f32[1024,24]{1,0}, /*index=45*/f32[1024]{0}, f32[2048,1024]{1,0}, f32[1024]{0}, f32[1024,1024]{1,0}, f32[1024]{0}, /*index=50*/f32[24,1024]{1,0}) %conditional), index=34, sharding={maximal device=0}, metadata={op_name="jit(init)/jit(main)/io_callback" source_file="/home/haohuanw/openpi/scripts/train.py" source_line=159}. You probably want to enrich the sharding annotations to prevent this from happening.
2024-12-21 17:32:13.329201: W external/xla/xla/service/gpu/ir_emitter_unnested.cc:1171] Unable to parse backend config for custom call: Could not convert JSON string to proto: : Root element must be a message.
Fall back to parse the raw backend config str.
NCCL version 2.21.5+cuda12.4
17:32:33.411 [I] Initialized train state:
['PaliGemma']['img']['Transformer']['encoder_norm']['bias']: (1152,)@float32
['PaliGemma']['img']['Transformer']['encoder_norm']['scale']: (1152,)@float32
['PaliGemma']['img']['Transformer']['encoderblock']['LayerNorm_0']['bias']: (27, 1152)@float32
['PaliGemma']['img']['Transformer']['encoderblock']['LayerNorm_0']['scale']: (27, 1152)@float32
['PaliGemma']['img']['Transformer']['encoderblock']['LayerNorm_1']['bias']: (27, 1152)@float32
['PaliGemma']['img']['Transformer']['encoderblock']['LayerNorm_1']['scale']: (27, 1152)@float32
['PaliGemma']['img']['Transformer']['encoderblock']['MlpBlock_0']['Dense_0']['bias']: (27, 4304)@float32
['PaliGemma']['img']['Transformer']['encoderblock']['MlpBlock_0']['Dense_0']['kernel']: (27, 1152, 4304)@float32
['PaliGemma']['img']['Transformer']['encoderblock']['MlpBlock_0']['Dense_1']['bias']: (27, 1152)@float32
['PaliGemma']['img']['Transformer']['encoderblock']['MlpBlock_0']['Dense_1']['kernel']: (27, 4304, 1152)@float32
['PaliGemma']['img']['Transformer']['encoderblock']['MultiHeadDotProductAttention_0']['key']['bias']: (27, 16, 72)@float32
['PaliGemma']['img']['Transformer']['encoderblock']['MultiHeadDotProductAttention_0']['key']['kernel']: (27, 1152, 16, 72)@float32
['PaliGemma']['img']['Transformer']['encoderblock']['MultiHeadDotProductAttention_0']['out']['bias']: (27, 1152)@float32
['PaliGemma']['img']['Transformer']['encoderblock']['MultiHeadDotProductAttention_0']['out']['kernel']: (27, 16, 72, 1152)@float32
['PaliGemma']['img']['Transformer']['encoderblock']['MultiHeadDotProductAttention_0']['query']['bias']: (27, 16, 72)@float32
['PaliGemma']['img']['Transformer']['encoderblock']['MultiHeadDotProductAttention_0']['query']['kernel']: (27, 1152, 16, 72)@float32
['PaliGemma']['img']['Transformer']['encoderblock']['MultiHeadDotProductAttention_0']['value']['bias']: (27, 16, 72)@float32
['PaliGemma']['img']['Transformer']['encoderblock']['MultiHeadDotProductAttention_0']['value']['kernel']: (27, 1152, 16, 72)@float32
['PaliGemma']['img']['embedding']['bias']: (1152,)@float32
['PaliGemma']['img']['embedding']['kernel']: (14, 14, 3, 1152)@float32
['PaliGemma']['img']['head']['bias']: (2048,)@float32
['PaliGemma']['img']['head']['kernel']: (1152, 2048)@float32
['PaliGemma']['img']['pos_embedding']: (1, 256, 1152)@float32
['PaliGemma']['llm']['embedder']['input_embedding']: (257152, 2048)@float32
['PaliGemma']['llm']['final_norm']['scale']: (2048,)@float32
['PaliGemma']['llm']['final_norm_1']['scale']: (1024,)@float32
['PaliGemma']['llm']['layers']['attn']['attn_vec_einsum']['w']: (18, 8, 256, 2048)@float32
['PaliGemma']['llm']['layers']['attn']['attn_vec_einsum_1']['w']: (18, 8, 256, 1024)@float32
['PaliGemma']['llm']['layers']['attn']['kv_einsum']['w']: (18, 2, 1, 2048, 256)@float32
['PaliGemma']['llm']['layers']['attn']['kv_einsum_1']['w']: (18, 2, 1, 1024, 256)@float32
['PaliGemma']['llm']['layers']['attn']['q_einsum']['w']: (18, 8, 2048, 256)@float32
['PaliGemma']['llm']['layers']['attn']['q_einsum_1']['w']: (18, 8, 1024, 256)@float32
['PaliGemma']['llm']['layers']['mlp']['gating_einsum']: (18, 2, 2048, 16384)@float32
['PaliGemma']['llm']['layers']['mlp']['linear']: (18, 16384, 2048)@float32
['PaliGemma']['llm']['layers']['mlp_1']['gating_einsum']: (18, 2, 1024, 4096)@float32
['PaliGemma']['llm']['layers']['mlp_1']['linear']: (18, 4096, 1024)@float32
['PaliGemma']['llm']['layers']['pre_attention_norm']['scale']: (18, 2048)@float32
['PaliGemma']['llm']['layers']['pre_attention_norm_1']['scale']: (18, 1024)@float32
['PaliGemma']['llm']['layers']['pre_ffw_norm']['scale']: (18, 2048)@float32
['PaliGemma']['llm']['layers']['pre_ffw_norm_1']['scale']: (18, 1024)@float32
['action_in_proj']['bias']: (1024,)@float32
['action_in_proj']['kernel']: (24, 1024)@float32
['action_out_proj']['bias']: (24,)@float32
['action_out_proj']['kernel']: (1024, 24)@float32
['action_time_mlp_in']['bias']: (1024,)@float32
['action_time_mlp_in']['kernel']: (2048, 1024)@float32
['action_time_mlp_out']['bias']: (1024,)@float32
['action_time_mlp_out']['kernel']: (1024, 1024)@float32
['state_proj']['bias']: (1024,)@float32
['state_proj']['kernel']: (24, 1024)@float32 (2046759:train.py:262)
17:32:33.470 [I] Progress on: -/500 rate:- remaining:? elapsed:00:00 postfix:-                    (2046759:tqdm_logging.py:145)
17:32:44.655 [I] Progress on: -/500 rate:- remaining:? elapsed:00:11 postfix:-                    (2046759:tqdm_logging.py:145)
17:33:02.261 [I] Progress on: 3.00it/500it rate:9.0s/it remaining:1:14:16 elapsed:00:28 postfix:- (2046759:tqdm_logging.py:145)
17:33:18.095 [I] Progress on: 5.00it/500it rate:8.3s/it remaining:1:08:42 elapsed:00:44 postfix:- (2046759:tqdm_logging.py:145)
17:33:28.993 [I] Progress on: 6.00it/500it rate:9.2s/it remaining:1:15:45 elapsed:00:55 postfix:- (2046759:tqdm_logging.py:145)
17:33:40.486 [I] Progress on: 7.00it/500it rate:10.0s/it remaining:1:21:45 elapsed:01:07 postfix:- (2046759:tqdm_logging.py:145)
17:34:02.566 [I] Progress on: 9.00it/500it rate:10.8s/it remaining:1:28:21 elapsed:01:29 postfix:- (2046759:tqdm_logging.py:145)
17:34:24.401 [I] Progress on: 11.0it/500it rate:11.1s/it remaining:1:30:51 elapsed:01:50 postfix:- (2046759:tqdm_logging.py:145)
17:34:46.086 [I] Progress on: 13.0it/500it rate:11.2s/it remaining:1:31:17 elapsed:02:12 postfix:- (2046759:tqdm_logging.py:145)
17:35:08.066 [I] Progress on: 15.0it/500it rate:11.4s/it remaining:1:32:08 elapsed:02:34 postfix:- (2046759:tqdm_logging.py:145)
17:35:29.913 [I] Progress on: 17.0it/500it rate:11.4s/it remaining:1:31:54 elapsed:02:56 postfix:- (2046759:tqdm_logging.py:145)
```