### PR TITLE
support lora in training script

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -109,7 +109,7 @@ def init_train_state(
         params = jax.experimental.io_callback(
             partial(_load_weights_and_validate, config.weight_loader), params, params, ordered=True
         )
-        if config.weight_freeze_regex:
+        if config.weight_freeze_regex is not None:
             freeze_weights_mask = training_utils.mask_from_regex(config.weight_freeze_regex, params)
             logging.info(
                 training_utils.to_readable_mask_info(freeze_weights_mask, lambda x: "frozen" if x else "not frozen")


### PR DESCRIPTION
add lora support, able to train with batch size of 96 on single gpu if only freeze gemma weights.

```
00:00:32.914 [I] Data loader initialized: [0].images['base_0_rgb']: (96, 224, 224, 3)@float32
[0].images['left_wrist_0_rgb']: (96, 224, 224, 3)@float32
[0].images['right_wrist_0_rgb']: (96, 224, 224, 3)@float32
[0].image_masks['base_0_rgb']: (96,)@bool
[0].image_masks['left_wrist_0_rgb']: (96,)@bool
[0].image_masks['right_wrist_0_rgb']: (96,)@bool
[0].state: (96, 24)@float32
[0].tokenized_prompt: (96, 48)@int32
[0].tokenized_prompt_mask: (96, 48)@int32
[1]: (96, 50, 24)@float32 (2686302:train.py:219)
00:00:33.761 [I] ['PaliGemma']['img']['Transformer']['encoder_norm']['bias']: not frozen
['PaliGemma']['img']['Transformer']['encoder_norm']['scale']: not frozen
['PaliGemma']['img']['Transformer']['encoderblock']['LayerNorm_0']['bias']: not frozen
['PaliGemma']['img']['Transformer']['encoderblock']['LayerNorm_0']['scale']: not frozen
['PaliGemma']['img']['Transformer']['encoderblock']['LayerNorm_1']['bias']: not frozen
['PaliGemma']['img']['Transformer']['encoderblock']['LayerNorm_1']['scale']: not frozen
['PaliGemma']['img']['Transformer']['encoderblock']['MlpBlock_0']['Dense_0']['bias']: not frozen
['PaliGemma']['img']['Transformer']['encoderblock']['MlpBlock_0']['Dense_0']['kernel']: not frozen
['PaliGemma']['img']['Transformer']['encoderblock']['MlpBlock_0']['Dense_1']['bias']: not frozen
['PaliGemma']['img']['Transformer']['encoderblock']['MlpBlock_0']['Dense_1']['kernel']: not frozen
['PaliGemma']['img']['Transformer']['encoderblock']['MultiHeadDotProductAttention_0']['key']['bias']: not frozen
['PaliGemma']['img']['Transformer']['encoderblock']['MultiHeadDotProductAttention_0']['key']['kernel']: not frozen
['PaliGemma']['img']['Transformer']['encoderblock']['MultiHeadDotProductAttention_0']['out']['bias']: not frozen
['PaliGemma']['img']['Transformer']['encoderblock']['MultiHeadDotProductAttention_0']['out']['kernel']: not frozen
['PaliGemma']['img']['Transformer']['encoderblock']['MultiHeadDotProductAttention_0']['query']['bias']: not frozen
['PaliGemma']['img']['Transformer']['encoderblock']['MultiHeadDotProductAttention_0']['query']['kernel']: not frozen
['PaliGemma']['img']['Transformer']['encoderblock']['MultiHeadDotProductAttention_0']['value']['bias']: not frozen
['PaliGemma']['img']['Transformer']['encoderblock']['MultiHeadDotProductAttention_0']['value']['kernel']: not frozen
['PaliGemma']['img']['embedding']['bias']: not frozen
['PaliGemma']['img']['embedding']['kernel']: not frozen
['PaliGemma']['img']['head']['bias']: not frozen
['PaliGemma']['img']['head']['kernel']: not frozen
['PaliGemma']['img']['pos_embedding']: not frozen
['PaliGemma']['llm']['embedder']['input_embedding']: frozen
['PaliGemma']['llm']['final_norm']['scale']: frozen
['PaliGemma']['llm']['final_norm_1']['scale']: not frozen
['PaliGemma']['llm']['layers']['attn']['attn_vec_einsum']['lora_a']: not frozen
['PaliGemma']['llm']['layers']['attn']['attn_vec_einsum']['lora_b']: not frozen
['PaliGemma']['llm']['layers']['attn']['attn_vec_einsum']['w']: frozen
['PaliGemma']['llm']['layers']['attn']['attn_vec_einsum_1']['w']: not frozen
['PaliGemma']['llm']['layers']['attn']['kv_einsum']['lora_a']: not frozen
['PaliGemma']['llm']['layers']['attn']['kv_einsum']['lora_b']: not frozen
['PaliGemma']['llm']['layers']['attn']['kv_einsum']['w']: frozen
['PaliGemma']['llm']['layers']['attn']['kv_einsum_1']['w']: not frozen
['PaliGemma']['llm']['layers']['attn']['q_einsum']['lora_a']: not frozen
['PaliGemma']['llm']['layers']['attn']['q_einsum']['lora_b']: not frozen
['PaliGemma']['llm']['layers']['attn']['q_einsum']['w']: frozen
['PaliGemma']['llm']['layers']['attn']['q_einsum_1']['w']: not frozen
['PaliGemma']['llm']['layers']['mlp']['gating_einsum']: frozen
['PaliGemma']['llm']['layers']['mlp']['linear']: frozen
['PaliGemma']['llm']['layers']['mlp_1']['gating_einsum']: not frozen
['PaliGemma']['llm']['layers']['mlp_1']['linear']: not frozen
['PaliGemma']['llm']['layers']['pre_attention_norm']['scale']: frozen
['PaliGemma']['llm']['layers']['pre_attention_norm_1']['scale']: not frozen
['PaliGemma']['llm']['layers']['pre_ffw_norm']['scale']: frozen
['PaliGemma']['llm']['layers']['pre_ffw_norm_1']['scale']: not frozen
['action_in_proj']['bias']: not frozen
['action_in_proj']['kernel']: not frozen
['action_out_proj']['bias']: not frozen
['action_out_proj']['kernel']: not frozen
['action_time_mlp_in']['bias']: not frozen
['action_time_mlp_in']['kernel']: not frozen
['action_time_mlp_out']['bias']: not frozen
['action_time_mlp_out']['kernel']: not frozen
['state_proj']['bias']: not frozen
['state_proj']['kernel']: not frozen (2686302:train.py:115)
2024-12-22 00:00:40.525689: W external/xla/xla/hlo/transforms/simplifiers/hlo_rematerialization.cc:3020] Can't reduce memory use below 38.60GiB (41444517703 bytes) by rematerialization; only reduced to 43.12GiB (46300074704 bytes), down from 43.12GiB (46298252728 bytes) originally
2024-12-22 00:00:42.172214: W external/xla/xla/service/gpu/ir_emitter_unnested.cc:1171] Unable to parse backend config for custom call: Could not convert JSON string to proto: : Root element must be a message.
Fall back to parse the raw backend config str.
00:00:57.984 [I] Initialized train state:
['PaliGemma']['img']['Transformer']['encoder_norm']['bias']: (1152,)@float32
['PaliGemma']['img']['Transformer']['encoder_norm']['scale']: (1152,)@float32
['PaliGemma']['img']['Transformer']['encoderblock']['LayerNorm_0']['bias']: (27, 1152)@float32
['PaliGemma']['img']['Transformer']['encoderblock']['LayerNorm_0']['scale']: (27, 1152)@float32
['PaliGemma']['img']['Transformer']['encoderblock']['LayerNorm_1']['bias']: (27, 1152)@float32
['PaliGemma']['img']['Transformer']['encoderblock']['LayerNorm_1']['scale']: (27, 1152)@float32
['PaliGemma']['img']['Transformer']['encoderblock']['MlpBlock_0']['Dense_0']['bias']: (27, 4304)@float32
['PaliGemma']['img']['Transformer']['encoderblock']['MlpBlock_0']['Dense_0']['kernel']: (27, 1152, 4304)@float32
['PaliGemma']['img']['Transformer']['encoderblock']['MlpBlock_0']['Dense_1']['bias']: (27, 1152)@float32
['PaliGemma']['img']['Transformer']['encoderblock']['MlpBlock_0']['Dense_1']['kernel']: (27, 4304, 1152)@float32
['PaliGemma']['img']['Transformer']['encoderblock']['MultiHeadDotProductAttention_0']['key']['bias']: (27, 16, 72)@float32
['PaliGemma']['img']['Transformer']['encoderblock']['MultiHeadDotProductAttention_0']['key']['kernel']: (27, 1152, 16, 72)@float32
['PaliGemma']['img']['Transformer']['encoderblock']['MultiHeadDotProductAttention_0']['out']['bias']: (27, 1152)@float32
['PaliGemma']['img']['Transformer']['encoderblock']['MultiHeadDotProductAttention_0']['out']['kernel']: (27, 16, 72, 1152)@float32
['PaliGemma']['img']['Transformer']['encoderblock']['MultiHeadDotProductAttention_0']['query']['bias']: (27, 16, 72)@float32
['PaliGemma']['img']['Transformer']['encoderblock']['MultiHeadDotProductAttention_0']['query']['kernel']: (27, 1152, 16, 72)@float32
['PaliGemma']['img']['Transformer']['encoderblock']['MultiHeadDotProductAttention_0']['value']['bias']: (27, 16, 72)@float32
['PaliGemma']['img']['Transformer']['encoderblock']['MultiHeadDotProductAttention_0']['value']['kernel']: (27, 1152, 16, 72)@float32
['PaliGemma']['img']['embedding']['bias']: (1152,)@float32
['PaliGemma']['img']['embedding']['kernel']: (14, 14, 3, 1152)@float32
['PaliGemma']['img']['head']['bias']: (2048,)@float32
['PaliGemma']['img']['head']['kernel']: (1152, 2048)@float32
['PaliGemma']['img']['pos_embedding']: (1, 256, 1152)@float32
['PaliGemma']['llm']['embedder']['input_embedding']: (257152, 2048)@float32
['PaliGemma']['llm']['final_norm']['scale']: (2048,)@float32
['PaliGemma']['llm']['final_norm_1']['scale']: (1024,)@float32
['PaliGemma']['llm']['layers']['attn']['attn_vec_einsum']['lora_a']: (18, 8, 256, 8, 64)@float32
['PaliGemma']['llm']['layers']['attn']['attn_vec_einsum']['lora_b']: (18, 8, 64, 2048)@float32
['PaliGemma']['llm']['layers']['attn']['attn_vec_einsum']['w']: (18, 8, 256, 2048)@float32
['PaliGemma']['llm']['layers']['attn']['attn_vec_einsum_1']['w']: (18, 8, 256, 1024)@float32
['PaliGemma']['llm']['layers']['attn']['kv_einsum']['lora_a']: (18, 2, 1, 2048, 64)@float32
['PaliGemma']['llm']['layers']['attn']['kv_einsum']['lora_b']: (18, 2, 1, 64, 1, 256)@float32
['PaliGemma']['llm']['layers']['attn']['kv_einsum']['w']: (18, 2, 1, 2048, 256)@float32
['PaliGemma']['llm']['layers']['attn']['kv_einsum_1']['w']: (18, 2, 1, 1024, 256)@float32
['PaliGemma']['llm']['layers']['attn']['q_einsum']['lora_a']: (18, 8, 2048, 64)@float32
['PaliGemma']['llm']['layers']['attn']['q_einsum']['lora_b']: (18, 8, 64, 8, 256)@float32
['PaliGemma']['llm']['layers']['attn']['q_einsum']['w']: (18, 8, 2048, 256)@float32
['PaliGemma']['llm']['layers']['attn']['q_einsum_1']['w']: (18, 8, 1024, 256)@float32
['PaliGemma']['llm']['layers']['mlp']['gating_einsum']: (18, 2, 2048, 16384)@float32
['PaliGemma']['llm']['layers']['mlp']['linear']: (18, 16384, 2048)@float32
['PaliGemma']['llm']['layers']['mlp_1']['gating_einsum']: (18, 2, 1024, 4096)@float32
['PaliGemma']['llm']['layers']['mlp_1']['linear']: (18, 4096, 1024)@float32
['PaliGemma']['llm']['layers']['pre_attention_norm']['scale']: (18, 2048)@float32
['PaliGemma']['llm']['layers']['pre_attention_norm_1']['scale']: (18, 1024)@float32
['PaliGemma']['llm']['layers']['pre_ffw_norm']['scale']: (18, 2048)@float32
['PaliGemma']['llm']['layers']['pre_ffw_norm_1']['scale']: (18, 1024)@float32
['action_in_proj']['bias']: (1024,)@float32
['action_in_proj']['kernel']: (24, 1024)@float32
['action_out_proj']['bias']: (24,)@float32
['action_out_proj']['kernel']: (1024, 24)@float32
['action_time_mlp_in']['bias']: (1024,)@float32
['action_time_mlp_in']['kernel']: (2048, 1024)@float32
['action_time_mlp_out']['bias']: (1024,)@float32
['action_time_mlp_out']['kernel']: (1024, 1024)@float32
['state_proj']['bias']: (1024,)@float32
['state_proj']['kernel']: (24, 1024)@float32 (2686302:train.py:223)
00:00:58.036 [I] Progress on: -/10 rate:- remaining:? elapsed:00:00 postfix:-                     (2686302:tqdm_logging.py:145)
2024-12-22 00:01:23.557767: W external/xla/xla/hlo/transforms/simplifiers/hlo_rematerialization.cc:3020] Can't reduce memory use below 38.44GiB (41279298024 bytes) by rematerialization; only reduced to 67.30GiB (72262036000 bytes), down from 70.82GiB (76042860440 bytes) originally
00:01:45.875 [I] Progress on: -/10 rate:- remaining:? elapsed:00:47 postfix:-                     (2686302:tqdm_logging.py:145)
^[00:01:59.734 [I] Progress on: 4.00it/10.0it rate:10.4s/it remaining:01:02 elapsed:01:01 postfix:- (2686302:tqdm_logging.py:145)
00:02:13.295 [I] Progress on: 7.00it/10.0it rate:6.2s/it remaining:00:18 elapsed:01:15 postfix:-  (2686302:tqdm_logging.py:145)
```