### PR TITLE
Make DeltaActions a no-op if actions are not available

### DIFF
--- a/src/openpi/transforms.py
+++ b/src/openpi/transforms.py
@@ -153,13 +153,14 @@ class DeltaActions(DataTransformFn):
     mask: Sequence[bool] | None
 
     def __call__(self, data: dict) -> dict:
-        state, actions = data["state"], data["actions"]
+        if "actions" not in data or self.mask is None:
+            return data
 
-        if self.mask is not None:
-            mask = np.asarray(self.mask)
-            dims = mask.shape[-1]
-            actions[..., :dims] -= np.expand_dims(np.where(mask, state[..., :dims], 0), axis=-2)
-            data["actions"] = actions
+        state, actions = data["state"], data["actions"]
+        mask = np.asarray(self.mask)
+        dims = mask.shape[-1]
+        actions[..., :dims] -= np.expand_dims(np.where(mask, state[..., :dims], 0), axis=-2)
+        data["actions"] = actions
 
         return data
 
@@ -174,13 +175,14 @@ class AbsoluteActions(DataTransformFn):
     mask: Sequence[bool] | None
 
     def __call__(self, data: dict) -> dict:
-        state, actions = data["state"], data["actions"]
+        if "actions" not in data or self.mask is None:
+            return data
 
-        if self.mask is not None:
-            mask = np.asarray(self.mask)
-            dims = mask.shape[-1]
-            actions[..., :dims] += np.expand_dims(np.where(mask, state[..., :dims], 0), axis=-2)
-            data["actions"] = actions
+        state, actions = data["state"], data["actions"]
+        mask = np.asarray(self.mask)
+        dims = mask.shape[-1]
+        actions[..., :dims] += np.expand_dims(np.where(mask, state[..., :dims], 0), axis=-2)
+        data["actions"] = actions
 
         return data
 

--- a/src/openpi/transforms_test.py
+++ b/src/openpi/transforms_test.py
@@ -24,6 +24,19 @@ def test_delta_actions():
     assert np.all(transformed["actions"] == np.array([[3, 2, 5], [5, 4, 7]]))
 
 
+def test_delta_actions_noop():
+    item = {"state": np.array([1, 2, 3]), "actions": np.array([[3, 4, 5], [5, 6, 7]])}
+
+    # No-op when the mask is disabled.
+    transform = _transforms.DeltaActions(mask=None)
+    assert transform(item) is item
+
+    # No-op when there are no actions in the input.
+    del item["actions"]
+    transform = _transforms.DeltaActions(mask=[True, False])
+    assert transform(item) is item
+
+
 def test_absolute_actions():
     item = {"state": np.array([1, 2, 3]), "actions": np.array([[3, 4, 5], [5, 6, 7]])}
 
@@ -32,6 +45,19 @@ def test_absolute_actions():
 
     assert np.all(transformed["state"] == np.array([1, 2, 3]))
     assert np.all(transformed["actions"] == np.array([[3, 6, 5], [5, 8, 7]]))
+
+
+def test_absolute_actions_noop():
+    item = {"state": np.array([1, 2, 3]), "actions": np.array([[3, 4, 5], [5, 6, 7]])}
+
+    # No-op when the mask is disabled.
+    transform = _transforms.AbsoluteActions(mask=None)
+    assert transform(item) is item
+
+    # No-op when there are no actions in the input.
+    del item["actions"]
+    transform = _transforms.AbsoluteActions(mask=[True, False])
+    assert transform(item) is item
 
 
 def test_make_bool_mask():


### PR DESCRIPTION
This is needed to support inference where actions are not available as part of the input.