### PR TITLE
Convert transforms to operate on single items

### DIFF
--- a/src/openpi/models/tokenizer_test.py
+++ b/src/openpi/models/tokenizer_test.py
@@ -3,7 +3,7 @@ from openpi.models import tokenizer as _tokenizer
 
 def test_tokenize():
     tokenizer = _tokenizer.PaligemmaTokenizer(max_len=10)
-    tokens, masks = tokenizer.tokenize(["Hello, world!", "This is a test"])
+    tokens, masks = tokenizer.tokenize("Hello, world!")
 
-    assert tokens.shape == (2, 10)
-    assert masks.shape == (2, 10)
+    assert tokens.shape == (10,)
+    assert masks.shape == (10,)

--- a/src/openpi/policies/calvin_policy.py
+++ b/src/openpi/policies/calvin_policy.py
@@ -20,8 +20,8 @@ class CalvinInputs(transforms.DataTransformFn):
                 "rgb_gripper": data["observation/rgb_gripper"],
             },
             "image_mask": {
-                "rgb_static": np.ones(1, dtype=np.bool_),
-                "rgb_gripper": np.ones(1, dtype=np.bool_),
+                "rgb_static": np.True_,
+                "rgb_gripper": np.True_,
             },
         }
 
@@ -35,4 +35,4 @@ class CalvinInputs(transforms.DataTransformFn):
 class CalvinOutputs(transforms.DataTransformFn):
     def __call__(self, data: dict) -> dict:
         # Only return the first 15 dims.
-        return {"actions": np.asarray(data["actions"][..., :15])}
+        return {"actions": np.asarray(data["actions"][:, :15])}

--- a/src/openpi/policies/droid_policy.py
+++ b/src/openpi/policies/droid_policy.py
@@ -11,7 +11,7 @@ class DroidInputs(transforms.DataTransformFn):
     action_dim: int
 
     def __call__(self, data: dict) -> dict:
-        state = np.concatenate([data["observation/joint_position"], data["observation/gripper_position"]], axis=1)
+        state = np.concatenate([data["observation/joint_position"], data["observation/gripper_position"]])
         state = transforms.pad_to_dim(state, self.action_dim)
 
         base_image = data["observation/exterior_image_1_left"]
@@ -24,9 +24,9 @@ class DroidInputs(transforms.DataTransformFn):
                 "right_wrist_0_rgb": np.zeros_like(base_image),
             },
             "image_mask": {
-                "base_0_rgb": np.ones(1, dtype=np.bool_),
-                "left_wrist_0_rgb": np.ones(1, dtype=np.bool_),
-                "right_wrist_0_rgb": np.zeros(1, dtype=np.bool_),
+                "base_0_rgb": np.True_,
+                "left_wrist_0_rgb": np.True_,
+                "right_wrist_0_rgb": np.False_,
             },
         }
 
@@ -40,4 +40,4 @@ class DroidInputs(transforms.DataTransformFn):
 class DroidOutputs(transforms.DataTransformFn):
     def __call__(self, data: dict) -> dict:
         # Only return the first 8 dims.
-        return {"actions": np.asarray(data["actions"][..., :8])}
+        return {"actions": np.asarray(data["actions"][:, :8])}

--- a/src/openpi/policies/libero_policy.py
+++ b/src/openpi/policies/libero_policy.py
@@ -20,8 +20,8 @@ class LiberoInputs(transforms.DataTransformFn):
                 "wrist_image": data["observation/wrist_image"],
             },
             "image_mask": {
-                "image": np.ones(1, dtype=np.bool_),
-                "wrist_image": np.ones(1, dtype=np.bool_),
+                "image": np.True_,
+                "wrist_image": np.True_,
             },
         }
 
@@ -35,4 +35,4 @@ class LiberoInputs(transforms.DataTransformFn):
 class LiberoOutputs(transforms.DataTransformFn):
     def __call__(self, data: dict) -> dict:
         # Only return the first 8 dims.
-        return {"actions": np.asarray(data["actions"][..., :8])}
+        return {"actions": np.asarray(data["actions"][:, :8])}

--- a/src/openpi/transforms_test.py
+++ b/src/openpi/transforms_test.py
@@ -69,22 +69,20 @@ def test_make_bool_mask():
 def test_tokenize_prompt():
     tokenizer = _tokenizer.PaligemmaTokenizer(max_len=12)
     transform = _transforms.TokenizePrompt(tokenizer)
-    item = {
-        "state": np.zeros((2, 10)),
-        "prompt": "Hello, world!",
-    }
 
-    transformed = transform(item)
+    data = transform({"prompt": "Hello, world!"})
 
-    assert transformed["tokenized_prompt"].shape == (2, 12)
-    assert transformed["tokenized_prompt_mask"].shape == (2, 12)
+    tok_prompt, tok_mask = tokenizer.tokenize("Hello, world!")
+    assert np.allclose(tok_prompt, data["tokenized_prompt"])
+    assert np.allclose(tok_mask, data["tokenized_prompt_mask"])
 
 
 def test_tokenize_prompt_default():
-    transform = _transforms.TokenizePrompt(_tokenizer.PaligemmaTokenizer(max_len=12))
-    item = {"state": np.zeros((10,))}
+    tokenizer = _tokenizer.PaligemmaTokenizer(max_len=12)
+    transform = _transforms.TokenizePrompt(tokenizer, default_prompt="This is a default prompt")
 
-    transformed = transform(item)
+    data = transform({})
 
-    assert transformed["tokenized_prompt"].shape == (12,)
-    assert transformed["tokenized_prompt_mask"].shape == (12,)
+    tok_prompt, tok_mask = tokenizer.tokenize("This is a default prompt")
+    assert np.allclose(tok_prompt, data["tokenized_prompt"])
+    assert np.allclose(tok_mask, data["tokenized_prompt_mask"])


### PR DESCRIPTION
This simplifies transforms by only requiring users to support single data items instead of batches.