### PR TITLE
remove dataset_root

### DIFF
--- a/src/openpi/training/config.py
+++ b/src/openpi/training/config.py
@@ -15,17 +15,10 @@ import openpi.models.tokenizer as _tokenizer
 import openpi.policies.aloha_policy as aloha_policy
 import openpi.policies.droid_policy as droid_policy
 import openpi.policies.libero_policy as libero_policy
-import openpi.shared.download as download
 import openpi.shared.normalize as _normalize
 import openpi.training.optimizer as _optimizer
 import openpi.training.weight_loaders as weight_loaders
 import openpi.transforms as _transforms
-
-
-def default_dataset_root() -> str:
-    """Default location for the dataset cache."""
-    return str(download.get_cache_dir() / "datasets")
-
 
 ModelType = _model.ModelType
 
@@ -53,9 +46,6 @@ class DataConfig:
     # sequence is defined by the `action_horizon` field in the model config. This should be adjusted if your
     # LeRobot dataset is using different keys to represent the action.
     action_sequence_keys: Sequence[str] = ("actions",)
-
-    # Indicates where the cached dataset should be stored. If None, the default directory will be used.
-    dataset_root: str | None = dataclasses.field(default_factory=default_dataset_root)
 
     # If true, will disable syncing the dataset from the huggingface hub. Allows training on local-only datasets.
     local_files_only: bool = False

--- a/src/openpi/training/data_loader.py
+++ b/src/openpi/training/data_loader.py
@@ -89,16 +89,13 @@ def create_dataset(data_config: _config.DataConfig, model_config: _model.BaseMod
     if repo_id == "fake":
         return FakeDataset(model_config, num_samples=1024)
 
-    dataset_meta = lerobot_dataset.LeRobotDatasetMetadata(
-        repo_id, root=data_config.dataset_root, local_files_only=data_config.local_files_only
-    )
+    dataset_meta = lerobot_dataset.LeRobotDatasetMetadata(repo_id, local_files_only=data_config.local_files_only)
     return lerobot_dataset.LeRobotDataset(
         data_config.repo_id,
         delta_timestamps={
             key: [t / dataset_meta.fps for t in range(model_config.action_horizon)]
             for key in data_config.action_sequence_keys
         },
-        root=data_config.dataset_root,
         local_files_only=data_config.local_files_only,
     )
 


### PR DESCRIPTION
Removes `dataset_root` and instead relies on setting `LEROBOT_HOME` to simplify dataset download + usage