### PR TITLE
Trim params during checkpoint conversion

### DIFF
--- a/src/openpi/models/exported_test.py
+++ b/src/openpi/models/exported_test.py
@@ -54,13 +54,28 @@ def test_processor_loading():
 
 
 @pytest.mark.manual
-def test_convert_to_openpi(tmp_path: pathlib.Path):
+def test_convert_pi0_to_openpi(tmp_path: pathlib.Path):
     output_dir = tmp_path / "output"
 
     exported.convert_to_openpi(
         "s3://openpi-assets/exported/pi0_base/model",
         output_dir,
-        processor="trossen_biarm_single_base_cam_24dim",
+        processor="trossen_biarm_single_base_cam_32dim",
+    )
+
+    # Make sure that we can load the params and norm stats.
+    _ = _model.restore_params(output_dir / "params")
+    _ = _checkpoints.load_norm_stats(output_dir / "assets")
+
+
+@pytest.mark.manual
+def test_convert_pi0_fast_to_openpi(tmp_path: pathlib.Path):
+    output_dir = tmp_path / "output"
+
+    exported.convert_to_openpi(
+        "s3://openpi-assets/exported/pi0_fast_base/model",
+        output_dir,
+        processor="trossen_biarm_single_base_cam_32dim",
     )
 
     # Make sure that we can load the params and norm stats.


### PR DESCRIPTION
This change makes sense that only the necessary parameters are exported during checkpoint conversion. As an added bonus, it also makes sure that we don't have any missing parameters.