### PR TITLE
Add a few extra connections to prevent exceeding the pool size

### DIFF
--- a/src/openpi/shared/download.py
+++ b/src/openpi/shared/download.py
@@ -236,7 +236,8 @@ def _download_boto3(
 def _get_s3_transfer_manager(
     session: boto3.Session, workers: int, botocore_config: botocore.config.Config | None = None
 ) -> s3_transfer.TransferManager:
-    config = botocore.config.Config(max_pool_connections=workers)
+    # Add a few extra connections to prevent exceeding the pool size.
+    config = botocore.config.Config(max_pool_connections=workers + 2)
     if botocore_config is not None:
         config = config.merge(botocore_config)
     s3client = session.client("s3", config=config)


### PR DESCRIPTION
This takes care of the following warning:
```
WARNING:urllib3.connectionpool:Connection pool is full, discarding connection: openpi-assets.s3.us-west-1.amazonaws.com. Connection pool size: 16
```