### PR TITLE
cancel delta data transforms for libero's action

### DIFF
--- a/src/openpi/training/config.py
+++ b/src/openpi/training/config.py
@@ -274,12 +274,6 @@ class LeRobotLiberoDataConfig(DataConfigFactory):
             inputs=[libero_policy.LiberoInputs(action_dim=model_config.action_dim, model_type=model_config.model_type)],
             outputs=[libero_policy.LiberoOutputs()],
         )
-        # Use delta actions (not for gripper)
-        delta_action_mask = _transforms.make_bool_mask(6, -1)
-        data_transforms = data_transforms.push(
-            inputs=[_transforms.DeltaActions(delta_action_mask)],
-            outputs=[_transforms.AbsoluteActions(delta_action_mask)],
-        )
 
         # Model transforms include things like tokenizing the prompt and action targets
         model_transforms = ModelTransformFactory()(model_config)


### PR DESCRIPTION
Hi, thank you very much for your excellent work. According to the description in the [Robosuite documentation](https://robosuite.ai/docs/modules/controllers.html)  (simulator used by LIBERO)
> When using any position-based control (OSC, IK, or JOINT_POSITION controllers), input actions are, by default, interpreted as delta values from the current state.

The actions in the Libero dataset are represented by delta actions, so it seems that we do not need to convert them to delta actions during training?