### PR TITLE
Fixed #311 configuration mistake

### DIFF
--- a/src/openpi/training/config.py
+++ b/src/openpi/training/config.py
@@ -487,7 +487,9 @@ _CONFIGS = [
     ),
     TrainConfig(
         name="pi0_fast_libero_low_mem_finetune",
-        model=pi0_fast.Pi0FASTConfig(paligemma_variant="gemma_2b_lora"),
+        model=pi0_fast.Pi0FASTConfig(
+            action_dim=7, action_horizon=10, max_token_len=180, paligemma_variant="gemma_2b_lora"
+        ),
         data=LeRobotLiberoDataConfig(
             repo_id="physical-intelligence/libero",
             base_config=DataConfig(


### PR DESCRIPTION
I tested this and it seems to train with `pi0_fast_libero_low_mem_finetune` which should fix #311/#317