### PR TITLE
Disable sharding for stats computation

### DIFF
--- a/scripts/compute_norm_stats.py
+++ b/scripts/compute_norm_stats.py
@@ -13,7 +13,7 @@ import openpi.shared.normalize as normalize
 import openpi.training.config as _config
 import openpi.training.data_loader as _data_loader
 import openpi.transforms as transforms
-
+import jax 
 
 class RemoveStrings(transforms.DataTransformFn):
     def __call__(self, x: dict) -> dict:
@@ -51,6 +51,7 @@ def main(config_name: str, max_frames: int | None = None):
     data_loader = _data_loader.TorchDataLoader(
         dataset,
         local_batch_size=1,
+        sharding=jax.sharding.SingleDeviceSharding(jax.devices()[0]),
         num_workers=8,
         shuffle=shuffle,
         num_batches=num_frames,


### PR DESCRIPTION
When running the `compute_norm_stats.py` script on a device with multiple GPUs, you get a sharding error because the batch (with size=1) cannot be split across the devices. 

You can fix this by prepending the environment variable `CUDA_VISIBLE_DEVICES=1,`to the command, but this PR makes it a bit more convenient by specifying `SingleDeviceSharding` in the dataloader constructor.
