### PR TITLE
Support for weighted dataset mixtures

### DIFF
--- a/scripts/compute_norm_stats.py
+++ b/scripts/compute_norm_stats.py
@@ -42,25 +42,24 @@ def create_dataset(config: _config.TrainConfig) -> tuple[_config.DataConfig, _da
             transformed_datasets.append(transformed_dataset)
 
         return data_config.mixture_configs, transformed_datasets
-    else:
-        dataset = _data_loader.create_dataset(data_config, config.model)
-        dataset = _data_loader.TransformedDataset(
-            dataset,
-            [
-                *data_config.repack_transforms.inputs,
-                *data_config.data_transforms.inputs,
-                # Remove strings since they are not supported by JAX and are not needed to compute norm stats.
-                RemoveStrings(),
-            ],
-        )
-        return [data_config], [dataset]
+    dataset = _data_loader.create_dataset(data_config, config.model)
+    dataset = _data_loader.TransformedDataset(
+        dataset,
+        [
+            *data_config.repack_transforms.inputs,
+            *data_config.data_transforms.inputs,
+            # Remove strings since they are not supported by JAX and are not needed to compute norm stats.
+            RemoveStrings(),
+        ],
+    )
+    return [data_config], [dataset]
 
 
 def main(config_name: str, max_frames: int | None = None):
     config = _config.get_config(config_name)
     data_configs, datasets = create_dataset(config)
 
-    for data_config, dataset in zip(data_configs, datasets):
+    for data_config, dataset in zip(data_configs, datasets, strict=True):
         num_frames = len(dataset)
         shuffle = False
 
@@ -88,7 +87,7 @@ def main(config_name: str, max_frames: int | None = None):
 
         output_path = config.assets_dirs / data_config.repo_id
         print(f"Writing stats to: {output_path}")
-        normalize.save(output_path, norm_stats) 
+        normalize.save(output_path, norm_stats)
 
 
 if __name__ == "__main__":

--- a/src/openpi/training/config.py
+++ b/src/openpi/training/config.py
@@ -221,16 +221,12 @@ class SimpleDataConfig(DataConfigFactory):
 class MixtureDataConfigFactory(DataConfigFactory):
     """Factory for creating a data config that samples from multiple datasets with weighted probabilities."""
 
-    # Override the repo_id field to make it optional since we'll have multiple datasets
     repo_id: str = "mixture"
 
-    # List of data config factories for the datasets we want to mix
     data_configs: Sequence[DataConfigFactory] = dataclasses.field(default_factory=list)
 
-    # Weights for each dataset (will be normalized)
     weights: Sequence[float] = None
 
-    # Whether to stop sampling when any dataset is exhausted
     stop_on_empty_dataset: bool = False
 
     @override

--- a/src/openpi/training/config.py
+++ b/src/openpi/training/config.py
@@ -635,66 +635,6 @@ _CONFIGS = [
         # Turn off EMA for LoRA finetuning.
         ema_decay=None,
     ),
-    TrainConfig(
-        name="pi0_fast_libero_mixture_low_mem",
-        model=pi0_fast.Pi0FASTConfig(
-            action_dim=7, action_horizon=10, max_token_len=180, paligemma_variant="gemma_2b_lora"
-        ),
-        data=MixtureDataConfigFactory(
-            data_configs=[
-                LeRobotLiberoDataConfig(
-                    repo_id="akuramshin/libero_10",
-                    base_config=DataConfig(
-                        local_files_only=True,
-                        prompt_from_task=True,
-                    ),
-                ),
-                LeRobotLiberoDataConfig(
-                    repo_id="akuramshin/libero_90",
-                    base_config=DataConfig(
-                        local_files_only=True,
-                        prompt_from_task=True,
-                    ),
-                ),
-            ],
-            weights=[1.0, 2.0],
-        ),
-        weight_loader=weight_loaders.CheckpointWeightLoader("s3://openpi-assets/checkpoints/pi0_fast_base/params"),
-        num_train_steps=30_000,
-        freeze_filter=pi0_fast.Pi0FASTConfig(
-            action_dim=7, action_horizon=10, max_token_len=180, paligemma_variant="gemma_2b_lora"
-        ).get_freeze_filter(),
-        # Turn off EMA for LoRA finetuning.
-        ema_decay=None,
-        wandb_enabled=False,
-    ),
-    TrainConfig(
-        name="pi0_fast_libero_mixture",
-        model=pi0_fast.Pi0FASTConfig(action_dim=7, action_horizon=10, max_token_len=180),
-        data=MixtureDataConfigFactory(
-            data_configs=[
-                LeRobotLiberoDataConfig(
-                    repo_id="akuramshin/libero_10",
-                    base_config=DataConfig(
-                        local_files_only=True,
-                        prompt_from_task=True,
-                    ),
-                ),
-                LeRobotLiberoDataConfig(
-                    repo_id="akuramshin/libero_90",
-                    base_config=DataConfig(
-                        local_files_only=True,
-                        prompt_from_task=True,
-                    ),
-                ),
-            ],
-            weights=[1.0, 2.0],
-        ),
-        weight_loader=weight_loaders.CheckpointWeightLoader("s3://openpi-assets/checkpoints/pi0_fast_base/params"),
-        num_train_steps=30_000,
-        wandb_enabled=False,
-        optimizer=_optimizer.AdamW(accumulation_steps=4),
-    ),
     #
     # Fine-tuning Aloha configs.
     #

--- a/src/openpi/training/config.py
+++ b/src/openpi/training/config.py
@@ -636,8 +636,10 @@ _CONFIGS = [
         ema_decay=None,
     ),
     TrainConfig(
-        name="pi0_fast_libero_mixture",
-        model=pi0_fast.Pi0FASTConfig(action_dim=7, action_horizon=10, max_token_len=180, paligemma_variant="gemma_2b_lora"),
+        name="pi0_fast_libero_mixture_low_mem",
+        model=pi0_fast.Pi0FASTConfig(
+            action_dim=7, action_horizon=10, max_token_len=180, paligemma_variant="gemma_2b_lora"
+        ),
         data=MixtureDataConfigFactory(
             data_configs=[
                 LeRobotLiberoDataConfig(
@@ -659,12 +661,39 @@ _CONFIGS = [
         ),
         weight_loader=weight_loaders.CheckpointWeightLoader("s3://openpi-assets/checkpoints/pi0_fast_base/params"),
         num_train_steps=30_000,
-         freeze_filter=pi0_fast.Pi0FASTConfig(
+        freeze_filter=pi0_fast.Pi0FASTConfig(
             action_dim=7, action_horizon=10, max_token_len=180, paligemma_variant="gemma_2b_lora"
         ).get_freeze_filter(),
         # Turn off EMA for LoRA finetuning.
         ema_decay=None,
         wandb_enabled=False,
+    ),
+    TrainConfig(
+        name="pi0_fast_libero_mixture",
+        model=pi0_fast.Pi0FASTConfig(action_dim=7, action_horizon=10, max_token_len=180),
+        data=MixtureDataConfigFactory(
+            data_configs=[
+                LeRobotLiberoDataConfig(
+                    repo_id="akuramshin/libero_10",
+                    base_config=DataConfig(
+                        local_files_only=True,
+                        prompt_from_task=True,
+                    ),
+                ),
+                LeRobotLiberoDataConfig(
+                    repo_id="akuramshin/libero_90",
+                    base_config=DataConfig(
+                        local_files_only=True,
+                        prompt_from_task=True,
+                    ),
+                ),
+            ],
+            weights=[1.0, 2.0],
+        ),
+        weight_loader=weight_loaders.CheckpointWeightLoader("s3://openpi-assets/checkpoints/pi0_fast_base/params"),
+        num_train_steps=30_000,
+        wandb_enabled=False,
+        optimizer=_optimizer.AdamW(accumulation_steps=4),
     ),
     #
     # Fine-tuning Aloha configs.

--- a/src/openpi/training/data_loader.py
+++ b/src/openpi/training/data_loader.py
@@ -84,7 +84,7 @@ class FakeDataset(Dataset):
 class MixtureDataset(Dataset[T_co]):
     """Dataset that samples from multiple datasets with weights similar to TensorFlow's sample_from_datasets.
 
-    For each element, a dataset is selected based on weights, and the next unused element
+    For each element, a dataset is selected based on weight[i], and the next unused element
     from that dataset is returned. Sampling is done without replacement.
     """
 
@@ -92,6 +92,7 @@ class MixtureDataset(Dataset[T_co]):
         self,
         datasets: Sequence[Dataset],
         weights: Sequence[float] | None = None,
+        *,
         stop_on_empty_dataset: bool = False,
         seed: int | None = None,
     ):
@@ -124,7 +125,7 @@ class MixtureDataset(Dataset[T_co]):
         self._sampling_order = self._calculate_sampling_order()
 
     def _calculate_sampling_order(self):
-        """Calculate the sampling order for this dataset."""
+        """Calculate the sampling order for this dataset mixture."""
         remaining_indices = [list(range(len(dataset))) for dataset in self._datasets]
         active_datasets = list(range(len(self._datasets)))
         weights = self._weights.copy()

--- a/src/openpi/training/data_loader.py
+++ b/src/openpi/training/data_loader.py
@@ -81,6 +81,95 @@ class FakeDataset(Dataset):
         return self._num_samples
 
 
+class MixtureDataset(Dataset[T_co]):
+    """Dataset that samples from multiple datasets with weights similar to TensorFlow's sample_from_datasets.
+
+    For each element, a dataset is selected based on weights, and the next unused element
+    from that dataset is returned. Sampling is done without replacement.
+    """
+
+    def __init__(
+        self,
+        datasets: Sequence[Dataset],
+        weights: Sequence[float] | None = None,
+        stop_on_empty_dataset: bool = False,
+        seed: int | None = None,
+    ):
+        """Create a dataset that samples from multiple datasets with given weights.
+
+        Args:
+            datasets: A sequence of datasets to sample from.
+            weights: Optional weights for each dataset. If not provided, uniform weights are used.
+            stop_on_empty_dataset: If True, stop when any dataset is exhausted.
+                If False, continue with the remaining datasets.
+            seed: Optional seed for reproducibility.
+        """
+        if not datasets:
+            raise ValueError("At least one dataset must be provided.")
+
+        self._datasets = datasets
+
+        # Use uniform weights if none provided
+        if weights is None:
+            weights = [1.0] * len(datasets)
+
+        if len(weights) != len(datasets):
+            raise ValueError(f"Number of weights ({len(weights)}) must match number of datasets ({len(datasets)}).")
+
+        self._weights = np.array(weights, dtype=np.float64)
+        self._stop_on_empty_dataset = stop_on_empty_dataset
+        self._rng = np.random.RandomState(seed)
+
+        self._length = sum(len(dataset) for dataset in datasets)
+        self._sampling_order = self._calculate_sampling_order()
+
+    def _calculate_sampling_order(self):
+        """Calculate the sampling order for this dataset."""
+        remaining_indices = [list(range(len(dataset))) for dataset in self._datasets]
+        active_datasets = list(range(len(self._datasets)))
+        weights = self._weights.copy()
+
+        sampling_order = []
+
+        while active_datasets and len(sampling_order) < self._length:
+            active_weights = weights[active_datasets]
+            total_weight = np.sum(active_weights)
+
+            if total_weight <= 0:
+                active_weights = np.ones(len(active_datasets)) / len(active_datasets)
+            else:
+                active_weights = active_weights / total_weight
+
+            dataset_idx = self._rng.choice(active_datasets, p=active_weights)
+
+            if remaining_indices[dataset_idx]:
+                element_idx = remaining_indices[dataset_idx].pop(0)
+                sampling_order.append((dataset_idx, element_idx))
+            else:
+                active_datasets.remove(dataset_idx)
+
+                if self._stop_on_empty_dataset:
+                    break
+
+        return sampling_order
+
+    def __len__(self) -> int:
+        return len(self._sampling_order)
+
+    def __getitem__(self, index: SupportsIndex) -> T_co:
+        # Convert index to integer
+        idx = index.__index__()
+
+        if idx >= len(self._sampling_order):
+            raise IndexError(f"Index {idx} out of range for dataset of length {len(self._sampling_order)}")
+
+        # Get the dataset_idx and element_idx from the sampling order
+        dataset_idx, element_idx = self._sampling_order[idx]
+
+        # Return the item from the selected dataset
+        return self._datasets[dataset_idx][element_idx]
+
+
 def create_dataset(data_config: _config.DataConfig, model_config: _model.BaseModelConfig) -> Dataset:
     """Create a dataset for training."""
     repo_id = data_config.repo_id
@@ -152,8 +241,24 @@ def create_data_loader(
     """
     data_config = config.data.create(config.assets_dirs, config.model)
 
-    dataset = create_dataset(data_config, config.model)
-    dataset = transform_dataset(dataset, data_config, skip_norm_stats=skip_norm_stats)
+    if data_config.mixture_configs:
+        datasets = [create_dataset(cfg, config.model) for cfg in data_config.mixture_configs]
+
+        transformed_datasets = []
+        for i, dataset in enumerate(datasets):
+            cfg = data_config.mixture_configs[i]
+            transformed_dataset = transform_dataset(dataset, cfg, skip_norm_stats=skip_norm_stats)
+            transformed_datasets.append(transformed_dataset)
+
+        dataset = MixtureDataset(
+            transformed_datasets,
+            weights=data_config.mixture_weights,
+            stop_on_empty_dataset=data_config.mixture_stop_on_empty,
+            seed=config.seed,
+        )
+    else:
+        dataset = create_dataset(data_config, config.model)
+        dataset = transform_dataset(dataset, data_config, skip_norm_stats=skip_norm_stats)
 
     data_loader = TorchDataLoader(
         dataset,

--- a/src/openpi/training/data_loader.py
+++ b/src/openpi/training/data_loader.py
@@ -110,7 +110,6 @@ class MixtureDataset(Dataset[T_co]):
 
         self._datasets = datasets
 
-        # Use uniform weights if none provided
         if weights is None:
             weights = [1.0] * len(datasets)
 
@@ -158,16 +157,13 @@ class MixtureDataset(Dataset[T_co]):
         return len(self._sampling_order)
 
     def __getitem__(self, index: SupportsIndex) -> T_co:
-        # Convert index to integer
         idx = index.__index__()
 
         if idx >= len(self._sampling_order):
             raise IndexError(f"Index {idx} out of range for dataset of length {len(self._sampling_order)}")
 
-        # Get the dataset_idx and element_idx from the sampling order
         dataset_idx, element_idx = self._sampling_order[idx]
 
-        # Return the item from the selected dataset
         return self._datasets[dataset_idx][element_idx]
 
 

--- a/src/openpi/training/data_loader_test.py
+++ b/src/openpi/training/data_loader_test.py
@@ -1,6 +1,7 @@
 import dataclasses
 
 import jax
+import pytest
 
 from openpi.models import pi0
 from openpi.training import config as _config
@@ -82,3 +83,126 @@ def test_with_real_dataset():
 
     for _, actions in batches:
         assert actions.shape == (config.batch_size, config.model.action_horizon, config.model.action_dim)
+
+
+class TaggedDataset(_data_loader.FakeDataset):
+    def __init__(self, model_config, num_samples, tag):
+        super().__init__(model_config, num_samples)
+        self.tag = tag
+
+    def __getitem__(self, index):
+        data = super().__getitem__(index)
+        data["tag"] = self.tag
+        return data
+
+
+def test_dataset_mixture():
+    config = _config.get_config("debug_mixture")
+
+    loader = _data_loader.create_data_loader(config, skip_norm_stats=True, num_batches=2)
+
+    assert loader.data_config().repo_id == config.data.repo_id
+
+    batches = list(loader)
+
+    assert len(batches) == 2
+
+    for batch in batches:
+        assert all(x.shape[0] == config.batch_size for x in jax.tree.leaves(batch))
+
+    for _, actions in batches:
+        assert actions.shape == (config.batch_size, config.model.action_horizon, config.model.action_dim)
+
+
+def test_dataset_mixture_init():
+    """Test basic initialization of WeightedSampleFromDatasets."""
+    config = pi0.Pi0Config(paligemma_variant="dummy", action_expert_variant="dummy")
+    dataset1 = _data_loader.FakeDataset(config, 20)
+    dataset2 = _data_loader.FakeDataset(config, 30)
+
+    mixture1 = _data_loader.MixtureDataset([dataset1, dataset2], seed=42, weights=[0.5, 0.5])
+    mixture2 = _data_loader.MixtureDataset([dataset1, dataset2], seed=42, weights=[0.5, 0.5])
+
+    assert mixture1._sampling_order == mixture2._sampling_order
+
+    mixture1 = _data_loader.MixtureDataset([dataset1, dataset2], seed=42, weights=[0.6, 0.4])
+    mixture2 = _data_loader.MixtureDataset([dataset1, dataset2], seed=42, weights=[0.4, 0.6])
+
+    assert mixture1._sampling_order != mixture2._sampling_order
+
+
+def test_weighted_sample_dataset_item_access():
+    """Test that items can be accessed from the dataset and are from the correct source."""
+    config = pi0.Pi0Config(paligemma_variant="dummy", action_expert_variant="dummy")
+
+    dataset1 = TaggedDataset(config, 20, "dataset1")
+    dataset2 = TaggedDataset(config, 30, "dataset2")
+
+    # Create mixture with equal weights
+    mixture = _data_loader.MixtureDataset([dataset1, dataset2], weights=[0.5, 0.5], seed=42)
+
+    # Count items from each dataset to verify distribution
+    sources = [mixture[i]["tag"] for i in range(len(mixture))]
+    dataset1_count = sources.count("dataset1")
+    dataset2_count = sources.count("dataset2")
+
+    # Since datasets are 20 and 30 items, and weights are equal,
+    # we should get all 20 from dataset1 and 30 from dataset2
+    assert dataset1_count == 20
+    assert dataset2_count == 30
+    assert dataset1_count + dataset2_count == len(mixture)
+
+
+def test_weighted_sample_dataset_edge_cases():
+    """Test edge cases like single dataset, empty dataset, etc."""
+    config = pi0.Pi0Config(paligemma_variant="dummy", action_expert_variant="dummy")
+
+    # Single dataset
+    single_dataset = _data_loader.FakeDataset(config, 20)
+    mixture = _data_loader.WeightedSampleFromDatasets([single_dataset])
+    assert len(mixture) == 20
+
+    # Empty datasets should be skipped
+    empty_dataset = _data_loader.FakeDataset(config, 0)
+    normal_dataset = _data_loader.FakeDataset(config, 20)
+
+    # This should work fine - empty dataset gets skipped
+    mixture = _data_loader.MixtureDataset([empty_dataset, normal_dataset], weights=[0.3, 0.7])
+    assert len(mixture) == 20
+
+    # With stop_on_empty_dataset=True and one empty dataset, length should be 0
+    mixture = _data_loader.MixtureDataset(
+        [empty_dataset, normal_dataset], weights=[0.3, 0.7], stop_on_empty_dataset=True
+    )
+    assert len(mixture) == 0
+
+    with pytest.warns(UserWarning):
+        mixture = _data_loader.MixtureDataset([normal_dataset, normal_dataset], weights=[0.0, 0.0])
+        # Should fall back to uniform weights
+        assert len(mixture) == 40
+
+
+def test_weighted_sampling_distribution():
+    """Test that sampling follows the specified weights."""
+    config = pi0.Pi0Config(paligemma_variant="dummy", action_expert_variant="dummy")
+
+    dataset1 = TaggedDataset(config, 1000, "dataset1")
+    dataset2 = TaggedDataset(config, 1000, "dataset2")
+
+    weights = [0.8, 0.2]
+    mixture = _data_loader.MixtureDataset(
+        [dataset1, dataset2],
+        weights=weights,
+        stop_on_empty_dataset=True,  # To get exact count
+        seed=42,
+    )
+
+    samples = [mixture[i]["tag"] for i in range(500)]
+    dataset1_count = samples.count("dataset1")
+    dataset2_count = samples.count("dataset2")
+
+    # Allow some statistical variance (within ±5%)
+    expected_dataset1 = 500 * 0.8
+    expected_dataset2 = 500 * 0.2
+    assert abs(dataset1_count - expected_dataset1) < 50
+    assert abs(dataset2_count - expected_dataset2) < 50

--- a/src/openpi/training/optimizer.py
+++ b/src/openpi/training/optimizer.py
@@ -71,6 +71,7 @@ class AdamW(OptimizerConfig):
     eps: float = 1e-8
     weight_decay: float = 1e-10
     clip_gradient_norm: float = 1.0
+    accumulation_steps: int = 1
 
     def create(
         self,
@@ -80,6 +81,8 @@ class AdamW(OptimizerConfig):
         tx = optax.adamw(
             lr, b1=self.b1, b2=self.b2, eps=self.eps, weight_decay=self.weight_decay, mask=weight_decay_mask
         )
+        if self.accumulation_steps > 1:
+            tx = optax.MultiSteps(tx, self.accumulation_steps)
 
         return optax.chain(optax.clip_by_global_norm(self.clip_gradient_norm), tx)
 


### PR DESCRIPTION
Created a new `MixtureDataset` Dataset type that supports weighted sampling from a list of datasets. Inspired by the [octo](https://github.com/octo-models/octo/tree/main) codebase that uses TensorFlow's [sample_from_datasets](https://www.tensorflow.org/api_docs/python/tf/data/Dataset#sample_from_datasets) to create oxe mixtures.

Since torch does not have a `sample_from_datasets` equivalent, I recreate a minimal implementation using numpy's [RandomState](https://numpy.org/doc/1.16/reference/generated/numpy.random.RandomState.html) to ensure a reproducible sampling order based on the seed.

I added tests in `data_loader_test.py`, but let me know if these are insufficient and more should be added.

I also added an `accumulation_steps` parameter to the `AdamW` optimizer factory to support gradient accumulation. I saw [here](https://github.com/Physical-Intelligence/openpi/issues/286#issuecomment-2655112920) that you guys had plans to add grad accumulation, but I was not able to find it. Let me know if this should not be part of this PR.