### PR TITLE
fix: add OpenCV dependencies to prevent training startup errors

### DIFF
--- a/scripts/docker/serve_policy.Dockerfile
+++ b/scripts/docker/serve_policy.Dockerfile
@@ -12,8 +12,8 @@ COPY --from=ghcr.io/astral-sh/uv:0.5.1 /uv /uvx /bin/
 
 WORKDIR /app
 
-# Needed because LeRobot uses git-lfs.
-RUN apt-get update && apt-get install -y git git-lfs
+# Needed because LeRobot uses git-lfs and OpenCV requires libgl1/libglib2.0-0
+RUN apt-get update && apt-get install -y git git-lfs libgl1 libglib2.0-0
 
 # Copy from the cache instead of linking since it's a mounted volume
 ENV UV_LINK_MODE=copy


### PR DESCRIPTION
### Problem:  

When following the README's Docker build process and running training, the container crashes with:

ImportError: libGL.so.1: cannot open shared object file

This occurs during OpenCV initialization, preventing training from starting.

### Root Cause:  
Docker image lacks OpenCV's required graphics libraries:  

• `libgl1` (OpenGL)  
• `libglib2.0-0` (GLib)  


###  Solution:  
Added to Dockerfile:  
```dockerfile
RUN apt-get update && apt-get install -y libgl1 libglib2.0-0
```  

### Verification:  
• Training now starts successfully  

• OpenCV modules load correctly  

• No impact on GPU compute (A800 verified)  


### Error Trace:

```
wandb: Tracking run with wandb version 0.19.1
wandb: Run data is saved locally in /workspace/openpi/wandb/run-20250515_123700-yf5ex8i4
wandb: Run `wandb offline` to turn off syncing.
wandb: Syncing run my_experiment
wandb:⭐️ View project at https://wandb.ai/XXXX
wandb: 🚀 View run at https://wandb.ai/XXXXXXX
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/root/.local/share/uv/python/cpython-3.11.9-linux-x86_64-gnu/lib/python3.11/multiprocessing/spawn.py", line 122, in spawn_main
    exitcode = _main(fd, parent_sentinel)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.local/share/uv/python/cpython-3.11.9-linux-x86_64-gnu/lib/python3.11/multiprocessing/spawn.py", line 131, in _main
    prepare(preparation_data)
  File "/root/.local/share/uv/python/cpython-3.11.9-linux-x86_64-gnu/lib/python3.11/multiprocessing/spawn.py", line 246, in prepare
    _fixup_main_from_path(data['init_main_from_path'])
  File "/root/.local/share/uv/python/cpython-3.11.9-linux-x86_64-gnu/lib/python3.11/multiprocessing/spawn.py", line 297, in _fixup_main_from_path
    main_content = runpy.run_path(main_path,
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen runpy>", line 280, in run_path
  File "/root/.local/share/uv/python/cpython-3.11.9-linux-x86_64-gnu/lib/python3.11/pkgutil.py", line 184, in <module>
    iter_importer_modules.register(
  File "/root/.local/share/uv/python/cpython-3.11.9-linux-x86_64-gnu/lib/python3.11/functools.py", line 892, in register
    if _is_union_type(cls):
       ^^^^^^^^^^^^^^^^^^^
  File "/root/.local/share/uv/python/cpython-3.11.9-linux-x86_64-gnu/lib/python3.11/functools.py", line 842, in _is_union_type
    from typing import get_origin, Union
  File "/.venv/lib/python3.11/site-packages/cv2/typing/__init__.py", line 60, in <module>
    import cv2.dnn
ImportError: libGL.so.1: cannot open shared object file: No such file or directory
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/root/.local/share/uv/python/cpython-3.11.9-linux-x86_64-gnu/lib/python3.11/multiprocessing/spawn.py", line 122, in spawn_main
    exitcode = _main(fd, parent_sentinel)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.local/share/uv/python/cpython-3.11.9-linux-x86_64-gnu/lib/python3.11/multiprocessing/spawn.py", line 131, in _main
    prepare(preparation_data)
  File "/root/.local/share/uv/python/cpython-3.11.9-linux-x86_64-gnu/lib/python3.11/multiprocessing/spawn.py", line 246, in prepare
    _fixup_main_from_path(data['init_main_from_path'])
  File "/root/.local/share/uv/python/cpython-3.11.9-linux-x86_64-gnu/lib/python3.11/multiprocessing/spawn.py", line 297, in _fixup_main_from_path
    main_content = runpy.run_path(main_path,
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen runpy>", line 280, in run_path
  File "/root/.local/share/uv/python/cpython-3.11.9-linux-x86_64-gnu/lib/python3.11/pkgutil.py", line 184, in <module>
    iter_importer_modules.register(
  File "/root/.local/share/uv/python/cpython-3.11.9-linux-x86_64-gnu/lib/python3.11/functools.py", line 892, in register
    if _is_union_type(cls):
       ^^^^^^^^^^^^^^^^^^^
  File "/root/.local/share/uv/python/cpython-3.11.9-linux-x86_64-gnu/lib/python3.11/functools.py", line 842, in _is_union_type
    from typing import get_origin, Union
  File "/.venv/lib/python3.11/site-packages/cv2/typing/__init__.py", line 60, in <module>
    import cv2.dnn
ImportError: libGL.so.1: cannot open shared object file: No such file or directory
```

