### PR TITLE
Change LEROBOT_HOME to HF_LEROBOT_HOME 

### DIFF
--- a/examples/libero/convert_libero_data_to_lerobot.py
+++ b/examples/libero/convert_libero_data_to_lerobot.py
@@ -20,7 +20,7 @@ Running this conversion script will take approximately 30 minutes.
 
 import shutil
 
-from lerobot.common.datasets.lerobot_dataset import LEROBOT_HOME
+from lerobot.common.datasets.lerobot_dataset import HF_LEROBOT_HOME
 from lerobot.common.datasets.lerobot_dataset import LeRobotDataset
 import tensorflow_datasets as tfds
 import tyro
@@ -36,7 +36,7 @@ RAW_DATASET_NAMES = [
 
 def main(data_dir: str, *, push_to_hub: bool = False):
     # Clean up any existing dataset in the output directory
-    output_path = LEROBOT_HOME / REPO_NAME
+    output_path = HF_LEROBOT_HOME / REPO_NAME
     if output_path.exists():
         shutil.rmtree(output_path)
 


### PR DESCRIPTION
convert_libero_data_to_lerobot.py throws an error

>     from lerobot.common.datasets.lerobot_dataset import LEROBOT_HOME
> ImportError: cannot import name 'LEROBOT_HOME' from 'lerobot.common.datasets.lerobot_dataset' 

See note in LeRobot repo: https://github.com/huggingface/lerobot/blob/bfd26eef5a781c8b6d74c43a2d8be318e5888515/lerobot/common/constants.py#L44C1-L45C1

> LEROBOT_HOME' is deprecated, please use 'HF_LEROBOT_HOME' instead