### PR TITLE
The current OpenPI environment installation error has been resolved.

### DIFF
--- a/examples/aloha_real/convert_aloha_data_to_lerobot.py
+++ b/examples/aloha_real/convert_aloha_data_to_lerobot.py
@@ -10,7 +10,7 @@ import shutil
 from typing import Literal
 
 import h5py
-from lerobot.common.datasets.lerobot_dataset import LEROBOT_HOME
+from lerobot.common.datasets.lerobot_dataset import HF_LEROBOT_HOME
 from lerobot.common.datasets.lerobot_dataset import LeRobotDataset
 from lerobot.common.datasets.push_dataset_to_hub._download_raw import download_raw
 import numpy as np
@@ -109,8 +109,8 @@ def create_empty_dataset(
             ],
         }
 
-    if Path(LEROBOT_HOME / repo_id).exists():
-        shutil.rmtree(LEROBOT_HOME / repo_id)
+    if Path(HF_LEROBOT_HOME / repo_id).exists():
+        shutil.rmtree(HF_LEROBOT_HOME / repo_id)
 
     return LeRobotDataset.create(
         repo_id=repo_id,
@@ -209,6 +209,7 @@ def populate_dataset(
             frame = {
                 "observation.state": state[i],
                 "action": action[i],
+                "task": task,
             }
 
             for camera, img_array in imgs_per_cam.items():
@@ -221,7 +222,7 @@ def populate_dataset(
 
             dataset.add_frame(frame)
 
-        dataset.save_episode(task=task)
+        dataset.save_episode()
 
     return dataset
 
@@ -229,7 +230,6 @@ def populate_dataset(
 def port_aloha(
     raw_dir: Path,
     repo_id: str,
-    raw_repo_id: str | None = None,
     task: str = "DEBUG",
     *,
     episodes: list[int] | None = None,
@@ -238,13 +238,12 @@ def port_aloha(
     mode: Literal["video", "image"] = "image",
     dataset_config: DatasetConfig = DEFAULT_DATASET_CONFIG,
 ):
-    if (LEROBOT_HOME / repo_id).exists():
-        shutil.rmtree(LEROBOT_HOME / repo_id)
+    if (HF_LEROBOT_HOME / repo_id).exists():
+        shutil.rmtree(HF_LEROBOT_HOME / repo_id)
 
     if not raw_dir.exists():
-        if raw_repo_id is None:
-            raise ValueError("raw_repo_id must be provided if raw_dir does not exist")
-        download_raw(raw_dir, repo_id=raw_repo_id)
+        raise ValueError("In the latest LeRobot codebase, the _download_raw script has been removed,\
+                         and as a result, the raw_repo_id parameter is no longer used.")
 
     hdf5_files = sorted(raw_dir.glob("episode_*.hdf5"))
 
@@ -262,7 +261,6 @@ def port_aloha(
         task=task,
         episodes=episodes,
     )
-    dataset.consolidate()
 
     if push_to_hub:
         dataset.push_to_hub()

--- a/examples/libero/convert_libero_data_to_lerobot.py
+++ b/examples/libero/convert_libero_data_to_lerobot.py
@@ -14,13 +14,13 @@ Note: to run the script, you need to install tensorflow_datasets:
 `uv pip install tensorflow tensorflow_datasets`
 
 You can download the raw Libero datasets from https://huggingface.co/datasets/openvla/modified_libero_rlds
-The resulting dataset will get saved to the $LEROBOT_HOME directory.
+The resulting dataset will get saved to the $HF_LEROBOT_HOME directory.
 Running this conversion script will take approximately 30 minutes.
 """
 
 import shutil
 
-from lerobot.common.datasets.lerobot_dataset import LEROBOT_HOME
+from lerobot.common.datasets.lerobot_dataset import HF_LEROBOT_HOME
 from lerobot.common.datasets.lerobot_dataset import LeRobotDataset
 import tensorflow_datasets as tfds
 import tyro
@@ -36,7 +36,7 @@ RAW_DATASET_NAMES = [
 
 def main(data_dir: str, *, push_to_hub: bool = False):
     # Clean up any existing dataset in the output directory
-    output_path = LEROBOT_HOME / REPO_NAME
+    output_path = HF_LEROBOT_HOME / REPO_NAME
     if output_path.exists():
         shutil.rmtree(output_path)
 
@@ -85,12 +85,10 @@ def main(data_dir: str, *, push_to_hub: bool = False):
                         "wrist_image": step["observation"]["wrist_image"],
                         "state": step["observation"]["state"],
                         "actions": step["action"],
+                        "task": step["language_instruction"].decode(),
                     }
                 )
-            dataset.save_episode(task=step["language_instruction"].decode())
-
-    # Consolidate the dataset, skip computing stats since we will do that later
-    dataset.consolidate(run_compute_stats=False)
+            dataset.save_episode()
 
     # Optionally push to the Hugging Face Hub
     if push_to_hub:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ readme = "README.md"
 requires-python = ">=3.11"
 license = { file = "LICENSE" }
 dependencies = [
-    "pip==24.2",
     "augmax>=0.3.4",
     "dm-tree>=0.1.8",
     "einops>=0.8.0",
@@ -16,19 +15,19 @@ dependencies = [
     "fsspec[gcs]>=2024.6.0",
     "gym-aloha>=0.1.1",
     "imageio>=2.36.1",
-    "jax[cuda12]==0.5.0",
+    "jax[cuda12]==0.5.3",
     "jaxtyping==0.2.36",
     "lerobot",
     "ml_collections==1.0.0",
-    "numpy==1.26.4",
+    "numpy>=1.22.4,<2.0.0",
     "numpydantic>=1.6.6",
     "opencv-python>=4.10.0.84",
     "openpi-client",
-    "orbax-checkpoint==0.11.1",
+    "orbax-checkpoint==0.11.13",
     "pillow>=11.0.0",
     "s3fs>=2024.9.0",
     "sentencepiece>=0.2.0",
-    "torch>=2.5.1",
+    "torch>=2.7.0",
     "tqdm-loggable>=0.2",
     "typing-extensions>=4.12.2",
     "tyro>=0.9.5",
@@ -36,21 +35,11 @@ dependencies = [
     "boto3>=1.35.7",
     "types-boto3[boto3,s3]>=1.35.7",
     "filelock>=3.16.1",
-    "beartype>=0.19.0",
+    "beartype==0.19.0",
     "treescope>=0.1.7",
     "transformers==4.48.1",
-    "sapien==3.0.0b1",
-    "scipy",
-    "mplib==0.1.1",
-    "gymnasium==0.29.1",
-    "trimesh==4.4.3",
-    "open3d==0.19.0",
-    "imageio",
-    "pydantic",
-    "zarr",
-    "openai",
-    "huggingface_hub",
-    "ffmpeg",
+    "rich>=14.0.0",
+    "polars>=1.30.0",
 ]
 
 
@@ -123,6 +112,7 @@ ignore = [
     "T201",   # We use print statements.
     "PD008",  # Lots of false positives.
     "ISC001", # Disabling to support ruff format.
+    "LOG015", # Use logger.info.
 ]
 unfixable = [
     "B905", # Fix defaults to strict=False, which is not what we want.

--- a/src/openpi/transforms.py
+++ b/src/openpi/transforms.py
@@ -300,15 +300,11 @@ class PromptFromLeRobotTask(DataTransformFn):
     tasks: dict[int, str]
 
     def __call__(self, data: DataDict) -> DataDict:
-        if "task_index" not in data:
-            raise ValueError('Cannot extract prompt without "task_index"')
-
-        task_index = int(data["task_index"])
-        if (prompt := self.tasks.get(task_index)) is None:
-            raise ValueError(f"{task_index=} not found in task mapping: {self.tasks}")
+        if "task" not in data:
+            raise ValueError('Cannot extract prompt: "task" key not found in data')
+        prompt = data["task"]
 
         return {**data, "prompt": prompt}
-
 
 def flatten_dict(tree: at.PyTree) -> dict:
     """Flatten a nested dictionary. Uses '/' as the separator."""


### PR DESCRIPTION
The following cases have been tested:

Data conversion using `examples/aloha_real/convert_aloha_data_to_lerobot.py`

Fine-tuning tested with the updated environment and code

File modification details:

`convert_aloha_data_to_lerobot.py`: Removed unused parameters due to the removal of `_download_raw.py` in LeRobot 2.0.

`convert_libero_data_to_lerobot.py`: Updated index access according to changes in LeRobot 2.0.

`transform.py`: Modified the prompt extraction logic to reflect the new position of language instructions when `prompt_from_task` is enabled.

`pyproject.toml`: Updated the LeRobot version to 2.0.