### PR TITLE
Fix missing EOS bug for pi0-FAST

### DIFF
--- a/src/openpi/models/tokenizer.py
+++ b/src/openpi/models/tokenizer.py
@@ -71,7 +71,7 @@ class FASTTokenizer:
             postfix_tokens = (
                 self._paligemma_tokenizer.encode("Action: ")
                 + action_tokens_in_pg.tolist()
-                + self._paligemma_tokenizer.encode("|")
+                + self._paligemma_tokenizer.encode("|", add_eos=True)
             )
         else:
             postfix_tokens = []


### PR DESCRIPTION
This bug affected training of pi0-FAST models in openpi (not inference of pre-trained models).
After training, actions will still be correctly decoded, but inference will be slower (since the model never predicts EOS, and thus always predicts the full 256 max tokens).
After the fix is applied, any newly trained model should predict EOS and thus inference should be faster :)