### PR TITLE
Add multi-node changes

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -1,7 +1,7 @@
-import os
 import dataclasses
 import functools
 import logging
+import os
 import platform
 from typing import Any
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -1,3 +1,4 @@
+import os
 import dataclasses
 import functools
 import logging
@@ -9,6 +10,15 @@ import flax.nnx as nnx
 from flax.training import common_utils
 import flax.traverse_util as traverse_util
 import jax
+
+if "MASTER_ADDR" in os.environ:
+    jax.distributed.initialize(
+        coordinator_address=f"{os.environ['MASTER_ADDR']}:{os.environ['MASTER_PORT']}",
+        process_id=int(os.environ["RANK"]),
+        num_processes=int(os.environ["WORLD_SIZE"]),
+        local_device_ids=[int(device_id) for device_id in os.environ["CUDA_VISIBLE_DEVICES"].split(",")],
+    )
+
 import jax.experimental
 import jax.numpy as jnp
 import numpy as np
@@ -151,6 +161,7 @@ def train_step(
         return jnp.mean(chunked_loss)
 
     train_rng = jax.random.fold_in(rng, state.step)
+    train_rng = jax.random.fold_in(train_rng, jax.process_index())
     observation, actions = batch
 
     # Filter out frozen params.
@@ -215,7 +226,8 @@ def main(config: _config.TrainConfig):
         overwrite=config.overwrite,
         resume=config.resume,
     )
-    init_wandb(config, resuming=resuming, enabled=config.wandb_enabled)
+    if jax.process_index() == 0:
+        init_wandb(config, resuming=resuming, enabled=config.wandb_enabled)
 
     data_loader = _data_loader.create_data_loader(
         config,
@@ -260,7 +272,7 @@ def main(config: _config.TrainConfig):
         with sharding.set_mesh(mesh):
             train_state, info = ptrain_step(train_rng, train_state, batch)
         infos.append(info)
-        if step % config.log_interval == 0:
+        if step % config.log_interval == 0 and jax.process_index() == 0:
             stacked_infos = common_utils.stack_forest(infos)
             reduced_info = jax.device_get(jax.tree.map(jnp.mean, stacked_infos))
             info_str = ", ".join(f"{k}={v:.4f}" for k, v in reduced_info.items())

--- a/src/openpi/training/checkpoints.py
+++ b/src/openpi/training/checkpoints.py
@@ -19,10 +19,12 @@ def initialize_checkpoint_dir(
     checkpoint_dir = epath.Path(checkpoint_dir).resolve()
     resuming = False
     if checkpoint_dir.exists():
-        if overwrite:
+        if overwrite and jax.process_index() == 0:
             checkpoint_dir.rmtree()
             checkpoint_dir.mkdir(parents=True, exist_ok=True)
             logging.info(f"Wiped checkpoint directory {checkpoint_dir}")
+        elif overwrite and jax.process_index() != 0:
+            pass
         elif resume:
             resuming = True
         else:

--- a/src/openpi/training/data_loader.py
+++ b/src/openpi/training/data_loader.py
@@ -164,8 +164,6 @@ def create_rlds_dataset(
         shuffle=shuffle,
         action_chunk_size=action_horizon,
         action_space=data_config.action_space,
-        world_size=jax.process_count(),
-        rank=jax.process_index(),
     )
 
 


### PR DESCRIPTION
Hi @uzhilinsky and @kpertsch. We've been using codebase with those modifications to finetune pi0 in multi-node multi-gpu setups, and as it was shown to be useful, so we've decided to do the PR.

The only issue is, I'm not sure that the sharding is correctly done for DROID RLDS. It seems most optimal way to do so is to pass 
```
tf.distribute.InputContext(num_input_pipelines=world_size, input_pipeline_id=rank, num_replicas_in_sync=world_size
``` 
in the DLimp constructor, but that would require fork/update to the repo.