### PR TITLE
Fix aloha reset position and gripper scaling

### DIFF
--- a/examples/aloha_real/Dockerfile
+++ b/examples/aloha_real/Dockerfile
@@ -6,7 +6,7 @@
 # Run the container:
 # docker run --rm -it --network=host -v /dev:/dev -v .:/app --privileged aloha_real /bin/bash
 
-FROM ros:noetic-robot@sha256:0e12e4db836e78c74c4b04c6d16f185d9a18d2b13cf5580747efa075eb6dc6e0
+FROM ros:noetic-robot@sha256:7cf0b9f6546abeba308ea42cb7ad3453f3e520e1af57cdf179fe915c939674bc
 SHELL ["/bin/bash", "-c"]
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/examples/aloha_real/real_env.py
+++ b/examples/aloha_real/real_env.py
@@ -112,12 +112,17 @@ class RealEnv:
         )
 
     def _reset_gripper(self):
-        """Set to position mode and do position resets: first open then close. Then change back to PWM mode"""
-        robot_utils.move_grippers(
-            [self.puppet_bot_left, self.puppet_bot_right], [constants.PUPPET_GRIPPER_JOINT_OPEN] * 2, move_time=0.5
-        )
+        """Set to position mode and do position resets: first close then open. Then change back to PWM mode
+
+        NOTE: This diverges from the original Aloha code which first opens then closes the gripper. Pi internal aloha data
+        was collected with the gripper starting in the open position. Leaving the grippers fully closed was also found to
+        increase the frequency of motor faults.
+        """
         robot_utils.move_grippers(
             [self.puppet_bot_left, self.puppet_bot_right], [constants.PUPPET_GRIPPER_JOINT_CLOSE] * 2, move_time=1
+        )
+        robot_utils.move_grippers(
+            [self.puppet_bot_left, self.puppet_bot_right], [constants.PUPPET_GRIPPER_JOINT_OPEN] * 2, move_time=0.5
         )
 
     def get_observation(self):

--- a/src/openpi/policies/aloha_policy.py
+++ b/src/openpi/policies/aloha_policy.py
@@ -137,17 +137,19 @@ def _gripper_to_angular(value):
     # The constants are taken from the Interbotix code.
     value = linear_to_radian(value, arm_length=0.036, horn_radius=0.022)
 
-    # Normalize to [0, 1].
-    # The values 0.4 and 1.5 were measured on an actual Trossen robot.
-    return _normalize(value, min_val=0.4, max_val=1.5)
+    # pi0 gripper data is normalized (0, 1) between encoder counts (2405, 3110).
+    # There are 4096 total encoder counts and aloha uses a zero of 2048.
+    # Converting this to radians means that the normalized inputs are between (0.5476, 1.6296)
+    return _normalize(value, min_val=0.5476, max_val=1.6296)
 
 
 def _gripper_from_angular(value):
     # Convert from the gripper position used by pi0 to the gripper position that is used by Aloha.
     # Note that the units are still angular but the range is different.
 
-    # The values 0.4 and 1.5 were measured on an actual Trossen robot.
-    value = _unnormalize(value, min_val=0.4, max_val=1.5)
+    # We do not scale the output since the trossen model predictions are already in radians.
+    # See the comment in _gripper_to_angular for a derivation of the constant
+    value = value + 0.5476
 
     # These values are coming from the Aloha code:
     # PUPPET_GRIPPER_JOINT_OPEN, PUPPET_GRIPPER_JOINT_CLOSE
@@ -157,7 +159,7 @@ def _gripper_from_angular(value):
 def _gripper_from_angular_inv(value):
     # Directly inverts the gripper_from_angular function.
     value = _unnormalize(value, min_val=-0.6213, max_val=1.4910)
-    return _normalize(value, min_val=0.4, max_val=1.5)
+    return value - 0.5476
 
 
 def _decode_aloha(data: dict, *, adapt_to_pi: bool = False) -> dict:

--- a/src/openpi/training/config.py
+++ b/src/openpi/training/config.py
@@ -479,6 +479,7 @@ _CONFIGS = [
         data=LeRobotAlohaDataConfig(
             assets=AssetsConfig(asset_id="trossen"),
         ),
+        policy_metadata={"reset_pose": [0, -1.5, 1.5, 0, 0, 0]},
     ),
     TrainConfig(
         name="pi0_aloha_towel",
@@ -487,6 +488,7 @@ _CONFIGS = [
             assets=AssetsConfig(asset_id="trossen"),
             default_prompt="fold the towel",
         ),
+        policy_metadata={"reset_pose": [0, -1.5, 1.5, 0, 0, 0]},
     ),
     TrainConfig(
         name="pi0_aloha_tupperware",
@@ -495,6 +497,7 @@ _CONFIGS = [
             assets=AssetsConfig(asset_id="trossen"),
             default_prompt="open the tupperware and put the food on the plate",
         ),
+        policy_metadata={"reset_pose": [0, -1.5, 1.5, 0, 0, 0]},
     ),
     #
     # Inference DROID configs.


### PR DESCRIPTION
- Updated the ros noetic docker container to fix broken keys
- Fixed a train test mismatch that was degrading performance on aloha after finding that the measured normalizations values were not accurate. New values are provided and calculated based on the pi0 encoder count normalization constants.
- Changed _gripper_from_angular to better match the pi runtime implementation
- Changed the reset position set in the example configs to match that of pi0 data collection.  