### PR TITLE
Fix Huggingface datasets dependency compatibility issue (#561)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "transformers==4.48.1",
     "rich>=14.0.0",
     "polars>=1.30.0",
+    "datasets==3.6.0",
 ]
 
 


### PR DESCRIPTION
## Description
Fixes the TypeError in `compute_norm_stats.py` caused by incompatibility with latest Huggingface datasets version 4.0.0.

## Problem
- `torch.stack(hf_dataset["timestamp"])` fails with TypeError when using datasets>=4.0.0
- `hf_dataset["timestamp"]` now returns a `datasets.Column` instead of tensor list/tuple
- This breaks the `compute_norm_stats.py` script

## Solution
- Pin `datasets==3.6.0` to maintain compatibility

## Testing
- Verified `compute_norm_stats.py` runs successfully with pinned versions
- No breaking changes to existing functionality

Closes #561