### PR TITLE
Fix Action Padding for openpi0 flow matching policy training

### DIFF
--- a/src/openpi/policies/droid_policy.py
+++ b/src/openpi/policies/droid_policy.py
@@ -64,7 +64,8 @@ class DroidInputs(transforms.DataTransformFn):
         }
 
         if "actions" in data:
-            inputs["actions"] = np.array(data["actions"])
+            actions = np.array(data["actions"])
+            inputs["actions"] = transforms.pad_to_dim(actions, self.action_dim)
 
         if "prompt" in data:
             if isinstance(data["prompt"], bytes):


### PR DESCRIPTION
small change to `DroidPolicyInputs` to pad actions to pi0 action dim