### PR TITLE
Add option for custom filtering based on json

### DIFF
--- a/examples/droid/README_train.md
+++ b/examples/droid/README_train.md
@@ -38,6 +38,10 @@ Run training:
 uv run --group rlds scripts/train.py pi0_fast_droid_finetune --exp-name=my_experiment --overwrite
 ```
 
+By default, training uses a simple filtering scheme that removes any frames that have little-to-no movement in the first half of the action chunk. Alternative, you can use a custom filtering scheme by providing a json that maps from episode keys to a list of time step ranges (denoted as a tuple of start and end time step indicies) in that episode you wish to keep. The episode key is a unique ID defined as `f"{recording_folderpath}--{file_path}"`. We choose this convention because both paths are easily accessible in the DROID RLDS episodes' metadata.
+
+We provide an example of such a filtering scheme in [filtering/get_droid_keep_ranges.py](examples/droid/filtering/get_droid_keep_ranges.py), which is significantly more aggressive than the default (and thus leads to policies that take significantly fewer idle actions). We recommend using the filter produced by this script, and have also provided a copy of the filter [here]() (we recommend re-running the script ). The filter json you wish to use can be specified by modifying the line `filter_dict_path="<path_to_filter_dict>"` in [src/openpi/training/config.py](src/openpi/training/config.py).
+
 **Note**: The original pi0-FAST-DROID model was trained with joint velocity actions.
 Joint velocity actions are not compatible with simulated evaluation environments (much harder to simulate). 
 Thus, we do not recommend training with joint velocity actions and instead use joint position actions here.

--- a/examples/droid/README_train.md
+++ b/examples/droid/README_train.md
@@ -20,7 +20,7 @@ You can download the DROID dataset with the following command (after installing 
 gsutil -m cp -r gs://gresearch/robotics/droid/1.0.1 <your_download_path>/droid/1.0.1
 ```
 
-Note that downloading version 1.0.1 is important (not v1.0.0): it contains the complete set of language annotations (~75k episodes) while v1.0.0 only has annotations for 30k episodes.
+Note that downloading version 1.0.1 is important (not v1.0.0): it contains the complete set of language annotations (~75k episodes) while v1.0.0 only has annotations for 30k episodes. If for some reason you would like to use another version, modify the line `version="1.0.1"` in the `DroidRldsDataset` object [here](src/openpi/training/droid_rlds_dataset.py).
 
 You will need 1.8TB of disk storage to download the DROID RLDS dataset.
 
@@ -38,9 +38,9 @@ Run training:
 uv run --group rlds scripts/train.py pi0_fast_droid_finetune --exp-name=my_experiment --overwrite
 ```
 
-By default, training uses a simple filtering scheme that removes any frames that have little-to-no movement in the first half of the action chunk. Alternative, you can use a custom filtering scheme by providing a json that maps from episode keys to a list of time step ranges (denoted as a tuple of start and end time step indicies) in that episode you wish to keep. The episode key is a unique ID defined as `f"{recording_folderpath}--{file_path}"`. We choose this convention because both paths are easily accessible in the DROID RLDS episodes' metadata.
+By default, training uses a simple filtering scheme that removes any frames that have little-to-no movement in the first half of the action chunk. Alternatively, you can use a custom filtering scheme by providing a json that maps from episode keys to a list of time step ranges (denoted as a tuple of start and end time step indicies) in that episode you wish to keep. The episode key is a unique ID defined as `f"{recording_folderpath}--{file_path}"`. We choose this convention because both paths are easily accessible in the DROID RLDS episodes' metadata.
 
-We provide an example of such a filtering scheme in [filtering/get_droid_keep_ranges.py](examples/droid/filtering/get_droid_keep_ranges.py), which is significantly more aggressive than the default (and thus leads to policies that take significantly fewer idle actions). We recommend using the filter produced by this script, and have also provided a copy of the filter [here]() (we recommend re-running the script ). The filter json you wish to use can be specified by modifying the line `filter_dict_path="<path_to_filter_dict>"` in [src/openpi/training/config.py](src/openpi/training/config.py).
+We provide an example of such a filtering scheme in [filtering/get_droid_keep_ranges.py](examples/droid/filtering/get_droid_keep_ranges.py), which is significantly more aggressive than the default (and thus leads to policies that take significantly fewer idle actions). We recommend using the filter produced by this script, and have also provided a copy of the filter [here](https://huggingface.co/KarlP/droid#filtering-data) specifically for `droid/1.0.1`. The filter json you wish to use can be specified by modifying the line `filter_dict_path="<path_to_filter_dict>"` in [src/openpi/training/config.py](src/openpi/training/config.py).
 
 **Note**: The original pi0-FAST-DROID model was trained with joint velocity actions.
 Joint velocity actions are not compatible with simulated evaluation environments (much harder to simulate). 

--- a/examples/droid/get_droid_keep_ranges.py
+++ b/examples/droid/get_droid_keep_ranges.py
@@ -1,0 +1,77 @@
+import os
+import json
+import numpy as np
+from tqdm import tqdm
+import tensorflow as tf
+import tensorflow_datasets as tfds
+
+os.environ["CUDA_VISIBLE_DEVICES"] = ""  # Set to the GPU you want to use, or leave empty for CPU
+
+builder = tfds.builder_from_directory(
+    # path to the `droid` directory (not its parent)
+    builder_dir="<path_to_droid_dataset_tfds_files>",
+)
+ds = builder.as_dataset(split="train", shuffle_files=False)
+tf.data.experimental.ignore_errors(ds)
+
+keep_ranges_path = "<path_to_where_to_save_the_json>"
+keep_ranges_map = {}
+if os.path.exists(keep_ranges_path):
+    with open(keep_ranges_path, "r") as f:
+        keep_ranges_map = json.load(f)
+
+min_idle_len = 7 # If more than this number of consecutive idle frames, filter all of them out
+min_non_idle_len = 16 # If fewer than this number of consecutive non-idle frames, filter all of them out
+
+for ep_idx, ep in enumerate(tqdm(ds)):
+    recording_folderpath = ep["episode_metadata"]["recording_folderpath"].numpy().decode()
+    file_path = ep["episode_metadata"]["file_path"].numpy().decode()
+
+    key = f"{recording_folderpath}--{file_path}"
+    if key in keep_ranges_map:
+        continue
+    
+    joint_velocities = []
+    for step in ep["steps"]:
+        joint_velocities.append(step["action_dict"]["joint_velocity"].numpy())
+    joint_velocities = np.array(joint_velocities)
+
+    is_idle_array = np.hstack([np.array([False]), np.all(np.abs(joint_velocities[1:] - joint_velocities[:-1]) < 1e-3, axis=1)])
+
+    # Get all idle ranges of length at least 7
+    padded = np.concatenate([[False], is_idle_array, [False]])
+
+    diff = np.diff(padded.astype(int))
+    true_starts = np.where(diff == 1)[0]  # +1 transitions
+    true_ends   = np.where(diff == -1)[0]  # -1 transitions
+
+    true_segment_masks = (true_ends - true_starts) >= min_idle_len
+    true_starts = true_starts[true_segment_masks]
+    true_ends = true_ends[true_segment_masks]
+
+    keep_mask = np.ones(len(joint_velocities), dtype=bool)
+    for start, end in zip(true_starts, true_ends):
+        keep_mask[start:end] = False
+
+    # Get all non-idle ranges of at least 16
+    padded = np.concatenate([[False], keep_mask, [False]])
+
+    diff = np.diff(padded.astype(int))
+    true_starts = np.where(diff == 1)[0]  # +1 transitions
+    true_ends   = np.where(diff == -1)[0]  # -1 transitions
+
+    true_segment_masks = (true_ends - true_starts) >= min_non_idle_len
+    true_starts = true_starts[true_segment_masks]
+    true_ends = true_ends[true_segment_masks]
+
+    keep_ranges_map[key] = []
+    for start, end in zip(true_starts, true_ends):
+        keep_ranges_map[key].append((int(start), int(end)))
+
+    if ep_idx % 1000 == 0:
+        with open(keep_ranges_path, "w") as f:
+            json.dump(keep_ranges_map, f)
+
+print("Done!")
+with open(keep_ranges_path, "w") as f:
+    json.dump(keep_ranges_map, f)

--- a/src/openpi/training/config.py
+++ b/src/openpi/training/config.py
@@ -344,6 +344,13 @@ class RLDSDroidDataConfig(DataConfigFactory):
     rlds_data_dir: str | None = None
     action_space: droid_rlds_dataset.DroidActionSpace | None = None
 
+    # Filtering options. Can pass a path to a dictionary that maps episodes to timestep ranges
+    # to tuples denoting ranges of time steps to keep (start, end).
+    # Path to the filter dictionary file.
+    filter_dict_path: str | None = None
+    # Number of frames to consider for filtering.
+    filter_last_n_in_ranges: int = 0
+
     @override
     def create(self, assets_dirs: pathlib.Path, model_config: _model.BaseModelConfig) -> DataConfig:
         repack_transform = _transforms.Group(

--- a/src/openpi/training/config.py
+++ b/src/openpi/training/config.py
@@ -93,6 +93,10 @@ class DataConfig:
     rlds_data_dir: str | None = None
     # Action space for DROID dataset.
     action_space: droid_rlds_dataset.DroidActionSpace | None = None
+    # Path to the filter dictionary file for DROID dataset
+    filter_dict_path: str | None = None
+    # Number of frames to consider for filtering for DROID dataset
+    filter_last_n_in_ranges: int = 0
 
 
 class GroupFactory(Protocol):
@@ -393,6 +397,8 @@ class RLDSDroidDataConfig(DataConfigFactory):
             use_quantile_norm=model_config.model_type == ModelType.PI0_FAST,
             rlds_data_dir=self.rlds_data_dir,
             action_space=self.action_space,
+            filter_dict_path=self.filter_dict_path,
+            filter_last_n_in_ranges=self.filter_last_n_in_ranges
         )
 
 
@@ -691,6 +697,9 @@ _CONFIGS = [
             # Set this to the path to your DROID RLDS dataset (the parent directory of the `droid` directory).
             rlds_data_dir="<path_to_droid_rlds_dataset>",
             action_space=droid_rlds_dataset.DroidActionSpace.JOINT_POSITION,
+            # Set this to the path for whatever filtering json you wish to use (or None for default filtering scheme)
+            filter_dict_path="<path_to_filtering_json_or_None>",
+            filter_last_n_in_ranges=10,
         ),
         weight_loader=weight_loaders.CheckpointWeightLoader("gs://openpi-assets/checkpoints/pi0_fast_base/params"),
         lr_schedule=_optimizer.CosineDecaySchedule(

--- a/src/openpi/training/data_loader.py
+++ b/src/openpi/training/data_loader.py
@@ -164,6 +164,8 @@ def create_rlds_dataset(
         shuffle=shuffle,
         action_chunk_size=action_horizon,
         action_space=data_config.action_space,
+        filter_dict_path=data_config.filter_dict_path,
+        filter_last_n_in_ranges=data_config.filter_last_n_in_ranges,
     )
 
 

--- a/src/openpi/training/droid_rlds_dataset.py
+++ b/src/openpi/training/droid_rlds_dataset.py
@@ -31,6 +31,8 @@ class DroidRldsDataset:
         shuffle_buffer_size: int = 250_000,
         num_parallel_reads: int = -1,  # -1 == tf.data.AUTOTUNE -- hack to not import tf at top level
         num_parallel_calls: int = -1,  # -1 == tf.data.AUTOTUNE -- hack to not import tf at top level
+        filter_dict_path = None,
+        filter_last_n_in_ranges = 0,
     ):
         # Import tensorflow here to not make it mandatory in case RLDS data loader is not used.
         import dlimp as dl
@@ -52,6 +54,35 @@ class DroidRldsDataset:
 
         # Repeat dataset so we never run out of data.
         dataset = dataset.repeat()
+
+        # Load the filter dictionary if provided.
+        # The filter dictionary is a JSON file that maps episode keys to ranges of frames to keep
+        # (e.g., {"<episode key>": [[0, 100], [200, 300]]} means keep frames 0-99 and 200-299).
+        if filter_dict_path is not None:
+            import json
+            from tqdm import tqdm
+
+            with open(filter_dict_path, "r") as f:
+                filter_dict = json.load(f)
+            keys_tensor = []
+            values_tensor = []
+
+            for episode_key, ranges in tqdm(filter_dict.items()):
+                for start, end in ranges:
+                    for t in range(start, end - filter_last_n_in_ranges):
+                        frame_key = f"{episode_key}--{t}"
+                        keys_tensor.append(frame_key)
+                        values_tensor.append(True)
+            self.filter_table = tf.lookup.StaticHashTable(
+                tf.lookup.KeyValueTensorInitializer(keys_tensor, values_tensor),
+                default_value=False
+            )
+            print("Filter hash table initialized")
+        else:
+            self.filter_table = tf.lookup.StaticHashTable(
+                tf.lookup.KeyValueTensorInitializer([""], [True]),
+                default_value=True
+            )
 
         def restructure(traj):
             """Reformat observation and action keys, sample language instruction."""
@@ -119,17 +150,25 @@ class DroidRldsDataset:
         # Flatten: map from trajectory dataset to dataset of individual action chunks
         dataset = dataset.flatten(num_parallel_calls=num_parallel_calls)
 
-        # Filter out frames where actions are idle. Must be done after flattening, as filter should apply per-frame.
-        def filter_idle(traj):
-            """Filter out chunks with idle actions.
-            --> we filter if at least first half of chunk does not move.
-            """
-            if action_space == DroidActionSpace.JOINT_POSITION:
-                # Compute delta to first position in action chunk
-                return tf.reduce_any(tf.abs(traj["actions"][: action_chunk_size // 2] - traj["actions"][:1]) > 1e-3)
-            return tf.reduce_any(tf.abs(traj["actions"][: action_chunk_size // 2]) > 1e-3)
+        def filter_from_dict(frame):
+            return frame["passes_filter"]
+        
+        dataset = dataset.filter(filter_from_dict)
 
-        dataset = dataset.filter(filter_idle)
+        if filter_dict_path is None:
+            # If filter_dict_path is not provided, use default filtering
+
+            # Filter out frames where actions are idle. Must be done after flattening, as filter should apply per-frame.
+            def filter_idle(traj):
+                """Filter out chunks with idle actions.
+                --> we filter if at least first half of chunk does not move.
+                """
+                if action_space == DroidActionSpace.JOINT_POSITION:
+                    # Compute delta to first position in action chunk
+                    return tf.reduce_any(tf.abs(traj["actions"][: action_chunk_size // 2] - traj["actions"][:1]) > 1e-3)
+                return tf.reduce_any(tf.abs(traj["actions"][: action_chunk_size // 2]) > 1e-3)
+
+            dataset = dataset.filter(filter_idle)
 
         # Decode images: RLDS saves encoded images, only decode now for efficiency
         def decode_images(traj):


### PR DESCRIPTION
The current training code only uses the default filter. This PR adds the option to filter based off of JSONs that map episodes to ranges of timesteps to keep.

- Changed `config.py` to also have the option to specify where that `json` filter file is.
- Cjamged `data_loader.py` to make use of above.
- Changed `DroidRldsDataset` to load that `json`, then filter out all frames not contained within that file.
- Added `examples/droid/get_droid_keep_ranges.py`, which uses a more aggressive filter (created by Karl) to generate such a json.
- Added reference to DROID hf repo, which contains a copy of that json run on `droid/1.0.1`.
- Updated `README_train.md` to reflect these changes.