### PR TITLE
libero: set use_quantile_norm=True in pi0-FAST LIBERO presets (fix #627)

### DIFF
--- a/src/openpi/training/config.py
+++ b/src/openpi/training/config.py
@@ -702,7 +702,7 @@ _CONFIGS = [
         model=pi0_fast.Pi0FASTConfig(action_dim=7, action_horizon=10, max_token_len=180),
         data=LeRobotLiberoDataConfig(
             repo_id="physical-intelligence/libero",
-            base_config=DataConfig(prompt_from_task=True),
+            base_config=DataConfig(prompt_from_task=True, use_quantile_norm=True),
             extra_delta_transform=True,
         ),
         # Note that we load the pi0-FAST base model checkpoint here.
@@ -718,7 +718,7 @@ _CONFIGS = [
         ),
         data=LeRobotLiberoDataConfig(
             repo_id="physical-intelligence/libero",
-            base_config=DataConfig(prompt_from_task=True),
+            base_config=DataConfig(prompt_from_task=True, use_quantile_norm=True),
             extra_delta_transform=True,
         ),
         weight_loader=weight_loaders.CheckpointWeightLoader("gs://openpi-assets/checkpoints/pi0_fast_base/params"),


### PR DESCRIPTION
This PR addresses #627 (Libero config bug) by ensuring quantile normalization is enabled for the LIBERO presets that use pi0-FAST. It is a minimal, non-duplicative change that modifies only the preset configuration to set:
base_config=DataConfig(prompt_from_task=True, use_quantile_norm=True)
for-
pi0_fast_libero
pi0_fast_libero_low_mem_finetune

Motivation & Context
pi0-FAST training/eval on LIBERO expects quantile normalization to be enabled for stable behavior. The previous preset definitions did not explicitly pass use_quantile_norm=True through the nested base_config=DataConfig(...), which could lead to runs where normalization is off. Making this explicit removes ambiguity and aligns the preset with the intended defaults.

What Changed (files & scope)
Edited: src/openpi/training/config.py
In both TrainConfig(...) blocks named pi0_fast_libero and pi0_fast_libero_low_mem_finetune, updated:
base_config=DataConfig(prompt_from_task=True, use_quantile_norm=True)

No other files touched. No duplicated code introduced. No behavior changes beyond enabling the expected normalization flag for these two presets.

with this PR-
uv run python - << 'PY'
from openpi.training import config as C
cfg = C.get_config("pi0_fast_libero")
print("use_quantile_norm =", getattr(getattr(cfg.data, "base_config", cfg.data), "use_quantile_norm", None))
PY
it prints use_quantile_norm = True

Checklist-
 pre-commit run locally
 ruff check / ruff format run locally (changed files)
 Reproduction + verification steps included
 References #627