### PR TITLE
fix:  Fix incorrect assets folder path in JAX to PyTorch    conversion

### DIFF
--- a/examples/convert_jax_model_to_pytorch.py
+++ b/examples/convert_jax_model_to_pytorch.py
@@ -533,7 +533,7 @@ def convert_pi0_checkpoint(
     safetensors.torch.save_model(pi0_model, os.path.join(output_path, "model.safetensors"))
 
     # Copy assets folder if it exists
-    assets_source = pathlib.Path(checkpoint_dir).parent / "assets"
+    assets_source = pathlib.Path(checkpoint_dir) / "assets"
     if assets_source.exists():
         assets_dest = pathlib.Path(output_path) / "assets"
         if assets_dest.exists():


### PR DESCRIPTION
Fix https://github.com/Physical-Intelligence/openpi/issues/638

The conversion script was looking for the assets folder in the wrong location. It was searching in the parent directory of the checkpoint (checkpoint_dir.parent / "assets") instead of inside the checkpoint directory itself (checkpoint_dir / "assets").

This ensures the assets folder is properly copied from the source checkpoint to the converted PyTorch model output directory.