### PR TITLE
broken link fix

### DIFF
--- a/docs/remote_inference.md
+++ b/docs/remote_inference.md
@@ -68,4 +68,4 @@ for step in range(num_steps):
 
 ```
 
-Here, the `host` and `port` arguments specify the IP address and port of the remote policy server. You can also specify these as command-line arguments to your robot code, or hard-code them in your robot codebase. The `observation` is a dictionary of observations and the prompt, following the specification of the policy inputs for the policy you are serving. We have concrete examples of how to construct this dictionary for different environments in the [simple client example](examples/simple_client/main.py).
+Here, the `host` and `port` arguments specify the IP address and port of the remote policy server. You can also specify these as command-line arguments to your robot code, or hard-code them in your robot codebase. The `observation` is a dictionary of observations and the prompt, following the specification of the policy inputs for the policy you are serving. We have concrete examples of how to construct this dictionary for different environments in the [simple client example](../examples/simple_client/main.py).


### PR DESCRIPTION
Currently `remote_inference.md` in `docs` links to `docs/examples/simple_client/main.py` instead of `examples/simple_client/main.py`. 