### PR TITLE
allow unstrictly loading model

### DIFF
--- a/src/openpi/models/model.py
+++ b/src/openpi/models/model.py
@@ -243,7 +243,7 @@ class BaseModelConfig(abc.ABC):
     def load_pytorch(self, train_config, weight_path: str):
         logger.info(f"train_config: {train_config}")
         model = pi0_pytorch.PI0Pytorch(config=train_config.model)
-        safetensors.torch.load_model(model, weight_path)
+        safetensors.torch.load_model(model, weight_path, strict=False)
         return model
 
     @abc.abstractmethod


### PR DESCRIPTION
In the latest release of safetensors, strictly loading the model will also compare the dtype. By setting strict=False, we allow load weights of different precisions. For example, if we save the model with a precision of bfloat16 (which is the default setting in the jax to pytorch script), we fail to load the checkpoint if we set strict=True.

Please refer to: https://github.com/huggingface/safetensors/blob/aa6c43d729868fc43918e862d42bfeaf60485d1d/bindings/python/py_src/safetensors/torch.py#L252.