### PR TITLE
fix(config): correct pi0.5 LIBERO config for issue #687

### DIFF
--- a/src/openpi/training/config.py
+++ b/src/openpi/training/config.py
@@ -733,7 +733,7 @@ _CONFIGS = [
     ),
     TrainConfig(
         name="pi05_libero",
-        model=pi0_config.Pi0Config(pi05=True, action_horizon=10, discrete_state_input=False),
+        model=pi0_config.Pi0Config(pi05=True, action_horizon=10),
         data=LeRobotLiberoDataConfig(
             repo_id="physical-intelligence/libero",
             base_config=DataConfig(prompt_from_task=True),


### PR DESCRIPTION
This PR sets discrete_state_input=True by default in the Pi0Config for pi0.5 libero, ensuring that state information is processed discretely as intended in the pi0.5 pipeline. 