### PR TITLE
feat: add wss support

### DIFF
--- a/packages/openpi-client/src/openpi_client/websocket_client_policy.py
+++ b/packages/openpi-client/src/openpi_client/websocket_client_policy.py
@@ -16,7 +16,10 @@ class WebsocketClientPolicy(_base_policy.BasePolicy):
     """
 
     def __init__(self, host: str = "0.0.0.0", port: Optional[int] = None, api_key: Optional[str] = None) -> None:
-        self._uri = f"ws://{host}"
+        if host.startswith("ws"):
+            self._uri = host
+        else:
+            self._uri = f"ws://{host}"
         if port is not None:
             self._uri += f":{port}"
         self._packer = msgpack_numpy.Packer()


### PR DESCRIPTION
This allows a user to pass a host like `wss://127.0.0.1:8000` instead of being forced to use `ws://`. This shouldn't change anyone's current behavior. 