### PR TITLE
run_aloha_sim.sh overrides the CMD to bypass uv run, due to bug in docker compose which is not allowing using GPUs inside the container

### DIFF
--- a/run_aloha_sim.sh
+++ b/run_aloha_sim.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Wrapper script to run ALOHA sim with GPU support
+# Docker Compose v2.39.2 has a bug where GPU passthrough doesn't work with 'up' command
+# This script uses docker run directly which works correctly
+
+set -e
+
+cd "$(dirname "$0")"
+
+# Build images if needed
+echo "Building Docker images..."
+docker build -t openpi_server -f scripts/docker/serve_policy.Dockerfile .
+docker build -t aloha_sim -f examples/aloha_sim/Dockerfile .
+
+# Start openpi_server in background
+# Note: We override the CMD to use PYTHONPATH instead of 'uv run' to avoid
+# package reinstallation that breaks JAX CUDA support
+echo "Starting openpi_server..."
+docker run -d \
+  --name aloha_openpi_server \
+  --gpus device=0 \
+  --network host \
+  -e SERVER_ARGS="--env ALOHA_SIM" \
+  -e OPENPI_DATA_HOME=/openpi_assets \
+  -e IS_DOCKER=true \
+  -v "$(pwd):/app" \
+  -v "${HOME}/.cache/openpi:/openpi_assets" \
+  openpi_server \
+  /bin/bash -c "cd /app && PYTHONPATH=/app/src:/.venv/lib/python3.11/site-packages /.venv/bin/python scripts/serve_policy.py --env ALOHA_SIM"
+
+# Wait for server to start
+echo "Waiting for server to start..."
+sleep 5
+
+# Start runtime container
+echo "Starting runtime container..."
+docker run -it --rm \
+  --name aloha_runtime \
+  --network host \
+  --privileged \
+  -v "$(pwd):/app" \
+  -v "$(pwd)/data:/data" \
+  aloha_sim
+
+# Cleanup: stop server when runtime exits
+echo "Stopping openpi_server..."
+docker stop aloha_openpi_server
+docker rm aloha_openpi_server

--- a/scripts/docker/serve_policy.Dockerfile
+++ b/scripts/docker/serve_policy.Dockerfile
@@ -29,7 +29,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     --mount=type=bind,source=packages/openpi-client/pyproject.toml,target=packages/openpi-client/pyproject.toml \
     --mount=type=bind,source=packages/openpi-client/src,target=packages/openpi-client/src \
-    GIT_LFS_SKIP_SMUDGE=1 uv sync --frozen --no-install-project --no-dev
+    GIT_LFS_SKIP_SMUDGE=1 uv sync --frozen --no-install-project
 
 # Copy transformers_replace files while preserving directory structure
 COPY src/openpi/models_pytorch/transformers_replace/ /tmp/transformers_replace/


### PR DESCRIPTION
`run_aloha_sim.sh`
```
Wrapper script that works around Docker Compose GPU bug
Overrides CMD to use PYTHONPATH instead of uv run to prevent JAX CUDA package reinstallation
Uses docker run --gpus directly (which works) instead of docker compose up (which is broken)
```