### PR TITLE
feat: added skip norm stats

### DIFF
--- a/scripts/serve_policy.py
+++ b/scripts/serve_policy.py
@@ -54,6 +54,9 @@ class Args:
     # Specifies how to load the policy. If not provided, the default policy for the environment will be used.
     policy: Checkpoint | Default = dataclasses.field(default_factory=Default)
 
+    # Disable normalization statistics
+    skip_norm_stats: bool = False
+
 
 # Default checkpoints that should be used for each environment.
 DEFAULT_CHECKPOINT: dict[EnvMode, Checkpoint] = {
@@ -90,7 +93,10 @@ def create_policy(args: Args) -> _policy.Policy:
     match args.policy:
         case Checkpoint():
             return _policy_config.create_trained_policy(
-                _config.get_config(args.policy.config), args.policy.dir, default_prompt=args.default_prompt
+                _config.get_config(args.policy.config),
+                args.policy.dir,
+                default_prompt=args.default_prompt,
+                skip_norm_stats=args.skip_norm_stats,
             )
         case Default():
             return create_default_policy(args.env, default_prompt=args.default_prompt)


### PR DESCRIPTION
Lerobot uses pre/post processing weights instead of norm stats. This allows a user to pass `--skip-norm-stats` to use an identity matrix.

I used these weights from my lerobot train, with field names converted:
https://huggingface.co/s3y/pi05-10-30-openpi/

and ran on my own openpi client. Everything worked as expected.