### PR TITLE
Add warning message when no weights are loaded for training

### DIFF
--- a/scripts/train_pytorch.py
+++ b/scripts/train_pytorch.py
@@ -447,6 +447,8 @@ def train_loop(config: _config.TrainConfig):
             (model.module if isinstance(model, torch.nn.parallel.DistributedDataParallel) else model), model_path
         )
         logging.info(f"Loaded PyTorch weights from {config.pytorch_weight_path}")
+    else:
+        logging.warning("No weights loaded, training from scratch.")
 
     # Optimizer + learning rate schedule from config
     warmup_steps = config.lr_schedule.warmup_steps

--- a/src/openpi/training/weight_loaders.py
+++ b/src/openpi/training/weight_loaders.py
@@ -31,6 +31,7 @@ class WeightLoader(Protocol):
 @dataclasses.dataclass(frozen=True)
 class NoOpWeightLoader(WeightLoader):
     def load(self, params: at.Params) -> at.Params:
+        logger.warning("No weights loaded, training from scratch.")
         return params
 
 


### PR DESCRIPTION
We expect most openpi intend to finetune from a pretrained model and not train from scratch. If `weight_loader` is not overridden, it defaults to `NoOpWeightLoader` and it may be helpful to warn the user in this case.

This is particularly relevant since the checkpoint loading differs from train vs. inference, where a given config can correctly load the inference weights, but will not use those same weights unless specified in the `weight_loader` (or `pytorch_weight_path`) config.