### PR TITLE
Fix hardcoded action dim in pi0 pytorch model

### DIFF
--- a/src/openpi/models_pytorch/pi0_pytorch.py
+++ b/src/openpi/models_pytorch/pi0_pytorch.py
@@ -97,14 +97,14 @@ class PI0Pytorch(nn.Module):
             precision=config.dtype,
         )
 
-        self.action_in_proj = nn.Linear(32, action_expert_config.width)
-        self.action_out_proj = nn.Linear(action_expert_config.width, 32)
+        self.action_in_proj = nn.Linear(config.action_dim, action_expert_config.width)
+        self.action_out_proj = nn.Linear(action_expert_config.width, config.action_dim)
 
         if self.pi05:
             self.time_mlp_in = nn.Linear(action_expert_config.width, action_expert_config.width)
             self.time_mlp_out = nn.Linear(action_expert_config.width, action_expert_config.width)
         else:
-            self.state_proj = nn.Linear(32, action_expert_config.width)
+            self.state_proj = nn.Linear(config.action_dim, action_expert_config.width)
             self.action_time_mlp_in = nn.Linear(2 * action_expert_config.width, action_expert_config.width)
             self.action_time_mlp_out = nn.Linear(action_expert_config.width, action_expert_config.width)
 


### PR DESCRIPTION
As seen [here](https://github.com/Physical-Intelligence/openpi/blob/981483dca0fd9acba698fea00aa6e52d56a66c58/src/openpi/models/pi0.py#L92-L100), the jax version of the pi0 modeling code correctly uses `config.action_dim` for the linear layer shapes. However, the corresponding pytorch code hardcodes this as 32.

This works fine for pi0/pi05 since they use an action dim of 32, but if users want to e.g. train a paligemma model with a different action dimension the pytorch code will error. This PR fixes this bug and uses the action dimension from the config.