### PR TITLE
Add typing-extensions dependency to openpi-client.

### DIFF
--- a/packages/openpi-client/pyproject.toml
+++ b/packages/openpi-client/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "numpy>=1.22.4,<2.0.0",
     "pillow>=9.0.0",
     "tree>=0.2.4",
+    "typing-extensions>=4.12.2",
     "websockets>=11.0",
 ]
 


### PR DESCRIPTION
The `openpi-client` subpackage requires typing-extensions but does not list it as a requirement in its dedicated `pyproject.toml` file. This PR fixes that, using the same version specifier as in the main `openpi` package.