### PR TITLE
add action mask in loss computation

### DIFF
--- a/src/openpi/models/pi0_config.py
+++ b/src/openpi/models/pi0_config.py
@@ -23,6 +23,7 @@ class Pi0Config(_model.BaseModelConfig):
 
     # Set the model specific defaults.
     action_dim: int = 32
+    actual_action_dim: int = 32 # the actual action dim in your dataset
     action_horizon: int = 50
     max_token_len: int = None  # type: ignore
     # Pi05 has two differences from Pi0:


### PR DESCRIPTION
### Motivation
In the implementation of π pytorch version, the loss is computed in the forward() as below:
[https://github.com/Physical-Intelligence/openpi/blob/main/src/openpi/models_pytorch/pi0_pytorch.py#L373](https://github.com/Physical-Intelligence/openpi/blob/main/src/openpi/models_pytorch/pi0_pytorch.py#L373)

**return F.mse_loss(u_t, v_t, reduction="none")**

But the dim of u_t and v_t are max_dim from the config (32 in π05). This means that the padded actions will also be included in the loss calculation. I think this may harm the model performance.

The lerobot π05 has fixed this by using action_mask when calculating the loss:
[https://github.com/huggingface/lerobot/blob/main/src/lerobot/policies/pi05/modeling_pi05.py#L1257](https://github.com/huggingface/lerobot/blob/main/src/lerobot/policies/pi05/modeling_pi05.py#L1257)

### Modification
In this PR, we create a new param **_actual_action_dim_** in src/openpi/models/pi0_config.py to represent the actual action dim.
And create a new param **_action_mask_** in class **_PI0Pytorch_**.

In the forward func, use the _action_mask_ to eliminate the impact of padded actions on the loss.

**return F.mse_loss(u_t, v_t, reduction="none") * self.action_mask**