### PR TITLE
fix(train): guard checkpoint dir ops with rank 0 to prevent DDP race condition

### DIFF
--- a/scripts/train_pytorch.py
+++ b/scripts/train_pytorch.py
@@ -329,15 +329,23 @@ def train_loop(config: _config.TrainConfig):
         else:
             raise FileNotFoundError(f"Experiment checkpoint directory {exp_checkpoint_dir} does not exist for resume")
     elif config.overwrite and config.checkpoint_dir.exists():
-        shutil.rmtree(config.checkpoint_dir)
-        logging.info(f"Overwriting checkpoint directory: {config.checkpoint_dir}")
+        # Only rank 0 should delete to avoid race conditions in DDP (see #868).
+        if is_main:
+            shutil.rmtree(config.checkpoint_dir)
+            logging.info(f"Overwriting checkpoint directory: {config.checkpoint_dir}")
+        if use_ddp:
+            dist.barrier()
 
     # Create checkpoint directory with experiment name
     if not resuming:
-        # For new runs, create experiment-specific checkpoint directory
+        # Only rank 0 creates the directory; other ranks wait behind the barrier.
+        if is_main:
+            exp_checkpoint_dir = config.checkpoint_dir
+            exp_checkpoint_dir.mkdir(parents=True, exist_ok=True)
+            logging.info(f"Created experiment checkpoint directory: {exp_checkpoint_dir}")
+        if use_ddp:
+            dist.barrier()
         exp_checkpoint_dir = config.checkpoint_dir
-        exp_checkpoint_dir.mkdir(parents=True, exist_ok=True)
-        logging.info(f"Created experiment checkpoint directory: {exp_checkpoint_dir}")
     else:
         # For resume, checkpoint_dir is already set to the experiment directory
         logging.info(f"Using existing experiment checkpoint directory: {config.checkpoint_dir}")


### PR DESCRIPTION
## What this PR does

Fixes the DDP race condition in `scripts/train_pytorch.py` when using `--overwrite` with multi-GPU training.

### Problem

When running with `torchrun --nproc_per_node=N` and `--overwrite`, **all ranks** attempt to `shutil.rmtree()` and `mkdir()` the checkpoint directory simultaneously. This causes `FileNotFoundError` because one rank deletes the directory while others are still trying to access or delete it.

```
[rank2]: FileNotFoundError: [Errno 2] No such file or directory: /path/to/checkpoint_dir
```

### Fix

Guard directory deletion and creation with `is_main` (rank 0 only), and add `dist.barrier()` calls to synchronize all ranks:

| Operation | Before | After |
|-----------|--------|-------|
| `shutil.rmtree()` | All ranks | Rank 0 only |
| `mkdir()` | All ranks | Rank 0 only |
| Synchronization | None | `dist.barrier()` after each op |

### Changes

| File | Change |
|------|--------|
| `scripts/train_pytorch.py` | Wrap checkpoint dir delete/create with rank 0 guard + barrier |

### Checklist

- [x] Backward compatible (single-GPU behavior unchanged, `is_main=True` when DDP is off)
- [x] Minimal change — 1 file, ~10 lines
- [x] Follows existing pattern (`is_main` guard already used for wandb init)

Closes #868