### PR TITLE
fix(train): handle NHWC images in wandb logging

### DIFF
--- a/scripts/train_pytorch.py
+++ b/scripts/train_pytorch.py
@@ -373,10 +373,23 @@ def train_loop(config: _config.TrainConfig):
         # Get batch size from the first image tensor
         batch_size = next(iter(sample_batch["image"].values())).shape[0]
         for i in range(min(5, batch_size)):
-            # Concatenate all camera views horizontally for this batch item
-            # Convert from NCHW to NHWC format for wandb
-            img_concatenated = torch.cat([img[i].permute(1, 2, 0) for img in sample_batch["image"].values()], axis=1)
-            img_concatenated = img_concatenated.cpu().numpy()
+            # Concatenate all camera views horizontally for this batch item.
+            # Images may be NCHW [C,H,W] or NHWC [H,W,C] depending on the
+            # dataloader backend; detect the layout and normalise to NHWC
+            # before handing off to wandb (see #877).
+            frames = []
+            for img in sample_batch["image"].values():
+                frame = img[i]
+                if frame.ndim == 3 and frame.shape[0] in (1, 3):
+                    # NCHW → NHWC
+                    frame = frame.permute(1, 2, 0)
+                frames.append(frame)
+            # Concatenate along the width axis (dim=1 in NHWC)
+            img_concatenated = torch.cat(frames, dim=1)
+            # Ensure pixel values are in [0, 1] for wandb
+            if img_concatenated.min() < 0:
+                img_concatenated = (img_concatenated + 1.0) / 2.0
+            img_concatenated = img_concatenated.clamp(0, 1).cpu().numpy()
             images_to_log.append(wandb.Image(img_concatenated))
 
         wandb.log({"camera_views": images_to_log}, step=0)


### PR DESCRIPTION
## What this PR does

Fixes wandb image logging crash when the dataloader returns images in NHWC format.

### Problem

The unified dataloader in PyTorch mode may return observation images in **NHWC** `[B, H, W, C]` layout (consistent with JAX/LeRobot conventions). The current wandb logging code unconditionally calls `permute(1, 2, 0)` assuming NCHW input. When images are already NHWC:

```
frame shape: [224, 224, 3]          # NHWC
after permute(1, 2, 0): [224, 3, 224]  # broken
concatenate 3 views on dim=1: [224, 9, 224]  # wandb rejects this
```

```
ValueError: Un-supported shape for image conversion [224, 9, 224]
```

### Fix

Detect the image layout before permuting:
- If `frame.shape[0]` is a small channel count (1 or 3) → treat as NCHW, permute to NHWC
- Otherwise → already NHWC, use as-is

Also:
- Concatenate along the width axis (dim=1 in NHWC) for correct horizontal tiling
- Normalise pixel values from `[-1, 1]` to `[0, 1]` when needed, avoiding wandb range warnings

### Changes

| File | Change |
|------|--------|
| `scripts/train_pytorch.py` | Robust NCHW/NHWC detection + value normalisation in wandb image logging |

### Checklist

- [x] Backward compatible (NCHW images still handled correctly)
- [x] Minimal change — 1 file
- [x] No new dependencies

Closes #877