### PR TITLE
docs: clarify Python 3.11 requirement for RLDS group

### DIFF
--- a/examples/droid/README_train.md
+++ b/examples/droid/README_train.md
@@ -8,8 +8,11 @@ for larger datasets like DROID -- they are working on improving it though). Belo
 
 ## Install
 
-We need a few additional dependencies for RLDS data loading. Run:
+We need a few additional dependencies for RLDS data loading. The RLDS group depends on `tensorflow-cpu==2.15.0`, which only ships wheels for **Python 3.11**. Make sure you create your virtual environment with Python 3.11 before syncing:
+
 ```bash
+uv python install 3.11
+uv venv --python 3.11
 uv sync --group rlds
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,8 @@ dev = [
     "pynvml>=12.0.0",
 ]
 rlds = [
+    # NOTE: tensorflow-cpu 2.15.0 only ships cp311 wheels on PyPI.
+    # Use `uv venv --python 3.11` before `uv sync --group rlds`.
     "dlimp",
     "tensorflow-cpu==2.15.0",
     "tensorflow-datasets==4.9.9",


### PR DESCRIPTION
## What this PR does

Documents the Python 3.11 requirement when using `uv sync --group rlds`.

### Problem

Running `uv sync --group rlds` with Python 3.12+ fails because `tensorflow-cpu==2.15.0` only has `cp311` wheels on PyPI:

```
error: Distribution tensorflow-cpu==2.15.0 can't be installed because it doesn't have a
source distribution or wheel for the current platform
hint: You're using CPython 3.12 (cp312), but tensorflow-cpu (v2.15.0) only has wheels
with the following Python ABI tag: cp311
```

### Fix

- Updated `examples/droid/README_train.md` with explicit `uv python install 3.11` + `uv venv --python 3.11` steps before `uv sync --group rlds`
- Added a comment in `pyproject.toml` next to the rlds group documenting this constraint

### Checklist

- [x] Minimal documentation change
- [x] No code changes

Closes #907