### PR TITLE
fix(train): ensure consistent color augmentation RNG across base and wrist cameras

### DIFF
--- a/src/openpi/models/model.py
+++ b/src/openpi/models/model.py
@@ -168,20 +168,23 @@ def preprocess_observation(
         if train:
             # Convert from [-1, 1] to [0, 1] for augmax.
             image = image / 2.0 + 0.5
+            sub_rngs = jax.random.split(rng, image.shape[0])
 
-            transforms = []
+            # Stage 1: Apply spatial transforms (base cameras only)
             if "wrist" not in key:
                 height, width = image.shape[1:3]
-                transforms += [
+                spatial_rngs = jax.vmap(lambda k: jax.random.fold_in(k, 0))(sub_rngs)
+                image = jax.vmap(augmax.Chain(
                     augmax.RandomCrop(int(width * 0.95), int(height * 0.95)),
                     augmax.Resize(width, height),
                     augmax.Rotate((-5, 5)),
-                ]
-            transforms += [
+                ))(spatial_rngs, image)
+
+            # Stage 2: Apply color transforms (all cameras, consistent RNG)
+            color_rngs = jax.vmap(lambda k: jax.random.fold_in(k, 1))(sub_rngs)
+            image = jax.vmap(augmax.Chain(
                 augmax.ColorJitter(brightness=0.3, contrast=0.4, saturation=0.5),
-            ]
-            sub_rngs = jax.random.split(rng, image.shape[0])
-            image = jax.vmap(augmax.Chain(*transforms))(sub_rngs, image)
+            ))(color_rngs, image)
 
             # Back to [-1, 1].
             image = image * 2.0 - 1.0

--- a/src/openpi/models/model.py
+++ b/src/openpi/models/model.py
@@ -174,17 +174,21 @@ def preprocess_observation(
             if "wrist" not in key:
                 height, width = image.shape[1:3]
                 spatial_rngs = jax.vmap(lambda k: jax.random.fold_in(k, 0))(sub_rngs)
-                image = jax.vmap(augmax.Chain(
-                    augmax.RandomCrop(int(width * 0.95), int(height * 0.95)),
-                    augmax.Resize(width, height),
-                    augmax.Rotate((-5, 5)),
-                ))(spatial_rngs, image)
+                image = jax.vmap(
+                    augmax.Chain(
+                        augmax.RandomCrop(int(width * 0.95), int(height * 0.95)),
+                        augmax.Resize(width, height),
+                        augmax.Rotate((-5, 5)),
+                    )
+                )(spatial_rngs, image)
 
             # Stage 2: Apply color transforms (all cameras, consistent RNG)
             color_rngs = jax.vmap(lambda k: jax.random.fold_in(k, 1))(sub_rngs)
-            image = jax.vmap(augmax.Chain(
-                augmax.ColorJitter(brightness=0.3, contrast=0.4, saturation=0.5),
-            ))(color_rngs, image)
+            image = jax.vmap(
+                augmax.Chain(
+                    augmax.ColorJitter(brightness=0.3, contrast=0.4, saturation=0.5),
+                )
+            )(color_rngs, image)
 
             # Back to [-1, 1].
             image = image * 2.0 - 1.0


### PR DESCRIPTION
## Problem

Fixes #859.

`augmax.Chain` splits the input RNG into sub-keys by transform count. Base cameras use 4 transforms (RandomCrop, Resize, Rotate, ColorJitter) while wrist cameras use only 1 (ColorJitter). This means ColorJitter receives different sub-RNGs for base vs. wrist cameras, even when given the same input seed.

The result: base and wrist cameras see **inconsistent color augmentation** within the same training sample, which may confuse the VLM about object colors across camera views.

## Fix

Split augmentation into two deterministic stages:
1. **Spatial transforms** (base cameras only): RandomCrop + Resize + Rotate
2. **Color transforms** (all cameras, shared RNG): ColorJitter

Both stages derive their RNG from the original key using `jax.random.fold_in` with different constants, ensuring:
- ColorJitter always uses the same RNG regardless of camera type
- Spatial transforms use a separate, independent RNG stream
- Results are fully deterministic and reproducible

## Changes

- `src/openpi/models/model.py`: Refactored image augmentation to use split RNG stages