### PR TITLE
Remove pytest from runtime model import

### DIFF
--- a/src/openpi/models_pytorch/gemma_pytorch.py
+++ b/src/openpi/models_pytorch/gemma_pytorch.py
@@ -1,6 +1,5 @@
 from typing import Literal
 
-import pytest
 import torch
 from torch import nn
 from transformers import GemmaForCausalLM
@@ -92,7 +91,7 @@ class PaliGemmaWithExpertModel(nn.Module):
         self,
         attention_mask: torch.Tensor | None = None,
         position_ids: torch.LongTensor | None = None,
-        past_key_values: list[torch.FloatTensor] | pytest.Cache | None = None,
+        past_key_values: list[torch.FloatTensor] | None = None,
         inputs_embeds: list[torch.FloatTensor] | None = None,
         use_cache: bool | None = None,
         adarms_cond: list[torch.Tensor] | None = None,


### PR DESCRIPTION
## Summary

This removes an unintended runtime dependency on `pytest` from `openpi.models_pytorch.gemma_pytorch`.

The only usage was in a type annotation for `past_key_values`:

- before: `list[torch.FloatTensor] | pytest.Cache | None`
- after: `list[torch.FloatTensor] | None`

## Why

  `pytest` should not be required to import or serve runtime model code.

  This showed up when using `openpi` in a production inference image that excludes dev dependencies.

  In our serving environment, `openpi.models_pytorch.gemma_pytorch` was imported during model load, which caused the server to fail if `pytest` was not installed. The `pytest` reference was only used in a type annotation and was not part of runtime behavior.
  

  ## Changes

  - removed `import pytest` from `src/openpi/models_pytorch/gemma_pytorch.py`
  - replaced the `pytest.Cache` annotation on `past_key_values` with a runtime-safe annotation

  ## Validation

  - verified that the only runtime use of `pytest` in this module was the type annotation
  - verified the change is isolated to this import and annotation

  ## Notes

  I kept this patch intentionally narrow to avoid changing model behavior or cache semantics beyond removing the accidental test-only dependency.