### PR TITLE
Use dependency groups in openpi-client

### DIFF
--- a/packages/openpi-client/pyproject.toml
+++ b/packages/openpi-client/pyproject.toml
@@ -15,8 +15,8 @@ dependencies = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-[tool.uv]
-dev-dependencies = ["pytest>=8.3.4"]
+[dependency-groups]
+dev = ["pytest>=8.3.4"]
 
 [tool.ruff]
 line-length = 120


### PR DESCRIPTION
## Summary

  This updates `packages/openpi-client/pyproject.toml` to use `dependency-groups.dev` instead of the deprecated `tool.uv.dev-dependencies` field.

  ## Why

  `uv` now warns that `tool.uv.dev-dependencies` is deprecated and will be removed in a future release.
  
  ```
  warning: The `tool.uv.dev-dependencies` field (used in `/Users/kkuan/openpi/openpi/packages/openpi-client/pyproject.toml`) is deprecated and will be removed in a future release; use `dependency-groups.dev` instead
  ```

  Keeping the package on the deprecated field adds noise to routine `uv` commands and risks a future break once support is removed.

  ## Validation

  - ran `uv lock --project packages/openpi-client --check --no-cache`
  - ran `uv lock --project packages/openpi-client --dry-run --no-cache`
  - verified there are no lockfile changes

  ## Notes

  This is a configuration-only change and does not alter runtime dependencies or package behavior.