### PR TITLE
Add UR5 fine-tuning example

### DIFF
--- a/examples/ur5/README.md
+++ b/examples/ur5/README.md
@@ -1,142 +1,80 @@
 # UR5 Example
 
-Below we provide an outline of how to implement the key components mentioned in the "Finetune on your data" section of the [README](../README.md) for finetuning on UR5 datasets.
+This example shows how to fine-tune a pi0 model on a UR5 dataset and serve the resulting policy.
+The UR5 has 6 revolute joints and a parallel-jaw gripper (7-dimensional state and action space),
+one base (third-person) camera, and one wrist camera.
 
-First, we will define the `UR5Inputs` and `UR5Outputs` classes, which map the UR5 environment to the model and vice versa. Check the corresponding files in `src/openpi/policies/libero_policy.py` for comments explaining each line.
+## Overview
 
-```python
+The key components live in two places:
 
-@dataclasses.dataclass(frozen=True)
-class UR5Inputs(transforms.DataTransformFn):
+- **`src/openpi/policies/ur5_policy.py`** — `UR5Inputs` and `UR5Outputs` transform classes
+  that map between the UR5 environment and the model's expected format.
+- **`src/openpi/training/config.py`** — `LeRobotUR5DataConfig` and three ready-to-use training
+  configs: `pi0_ur5` (full fine-tune), `pi0_ur5_low_mem_finetune` (LoRA), and `pi0_fast_ur5`.
 
-    model_type: _model.ModelType = _model.ModelType.PI0
+## Step 1 — Prepare your dataset
 
-    def __call__(self, data: dict) -> dict:
-        # First, concatenate the joints and gripper into the state vector.
-        state = np.concatenate([data["joints"], data["gripper"]])
+Convert your raw UR5 recordings to LeRobot format using the provided script. Adapt the data
+loading logic in the script to match your actual data format (rosbag, HDF5, etc.).
 
-        # Possibly need to parse images to uint8 (H,W,C) since LeRobot automatically
-        # stores as float32 (C,H,W), gets skipped for policy inference.
-        base_image = _parse_image(data["base_rgb"])
-        wrist_image = _parse_image(data["wrist_rgb"])
-
-        # Create inputs dict.
-        inputs = {
-            "state": state,
-            "image": {
-                "base_0_rgb": base_image,
-                "left_wrist_0_rgb": wrist_image,
-                # Since there is no right wrist, replace with zeros
-                "right_wrist_0_rgb": np.zeros_like(base_image),
-            },
-            "image_mask": {
-                "base_0_rgb": np.True_,
-                "left_wrist_0_rgb": np.True_,
-                # Since the "slot" for the right wrist is not used, this mask is set
-                # to False
-                "right_wrist_0_rgb": np.True_ if self.model_type == _model.ModelType.PI0_FAST else np.False_,
-            },
-        }
-
-        if "actions" in data:
-            inputs["actions"] = data["actions"]
-
-        # Pass the prompt (aka language instruction) to the model.
-        if "prompt" in data:
-            inputs["prompt"] = data["prompt"]
-
-        return inputs
-
-
-@dataclasses.dataclass(frozen=True)
-class UR5Outputs(transforms.DataTransformFn):
-
-    def __call__(self, data: dict) -> dict:
-        # Since the robot has 7 action dimensions (6 DoF + gripper), return the first 7 dims
-        return {"actions": np.asarray(data["actions"][:, :7])}
-
+```bash
+uv run examples/ur5/convert_ur5_data_to_lerobot.py --data_dir /path/to/ur5_data
 ```
 
-Next, we will define the `UR5DataConfig` class, which defines how to process raw UR5 data from LeRobot dataset for training. For a full example, see the `LeRobotLiberoDataConfig` config in the [training config file](https://github.com/physical-intelligence/openpi/blob/main/src/openpi/training/config.py).
+To push the converted dataset to the Hugging Face Hub:
 
-```python
-
-@dataclasses.dataclass(frozen=True)
-class LeRobotUR5DataConfig(DataConfigFactory):
-
-    @override
-    def create(self, assets_dirs: pathlib.Path, model_config: _model.BaseModelConfig) -> DataConfig:
-        # Boilerplate for remapping keys from the LeRobot dataset. We assume no renaming needed here.
-        repack_transform = _transforms.Group(
-            inputs=[
-                _transforms.RepackTransform(
-                    {
-                        "base_rgb": "image",
-                        "wrist_rgb": "wrist_image",
-                        "joints": "joints",
-                        "gripper": "gripper",
-                        "prompt": "prompt",
-                    }
-                )
-            ]
-        )
-
-        # These transforms are the ones we wrote earlier.
-        data_transforms = _transforms.Group(
-            inputs=[UR5Inputs(action_dim=model_config.action_dim, model_type=model_config.model_type)],
-            outputs=[UR5Outputs()],
-        )
-
-        # Convert absolute actions to delta actions.
-        # By convention, we do not convert the gripper action (7th dimension).
-        delta_action_mask = _transforms.make_bool_mask(6, -1)
-        data_transforms = data_transforms.push(
-            inputs=[_transforms.DeltaActions(delta_action_mask)],
-            outputs=[_transforms.AbsoluteActions(delta_action_mask)],
-        )
-
-        # Model transforms include things like tokenizing the prompt and action targets
-        # You do not need to change anything here for your own dataset.
-        model_transforms = ModelTransformFactory()(model_config)
-
-        # We return all data transforms for training and inference. No need to change anything here.
-        return dataclasses.replace(
-            self.create_base_config(assets_dirs),
-            repack_transforms=repack_transform,
-            data_transforms=data_transforms,
-            model_transforms=model_transforms,
-        )
-
+```bash
+uv run examples/ur5/convert_ur5_data_to_lerobot.py --data_dir /path/to/ur5_data --push_to_hub
 ```
 
-Finally, we define the TrainConfig for our UR5 dataset. Here, we define a config for fine-tuning pi0 on our UR5 dataset. See the [training config file](https://github.com/physical-intelligence/openpi/blob/main/src/openpi/training/config.py) for more examples, e.g. for pi0-FAST or for LoRA fine-tuning.
+The script expects each episode to be a sub-directory containing:
 
-```python
-TrainConfig(
-    name="pi0_ur5",
-    model=pi0.Pi0Config(),
-    data=LeRobotUR5DataConfig(
-        repo_id="your_username/ur5_dataset",
-        # This config lets us reload the UR5 normalization stats from the base model checkpoint.
-        # Reloading normalization stats can help transfer pre-trained models to new environments.
-        # See the [norm_stats.md](../docs/norm_stats.md) file for more details.
-        assets=AssetsConfig(
-            assets_dir="gs://openpi-assets/checkpoints/pi0_base/assets",
-            asset_id="ur5e",
-        ),
-        base_config=DataConfig(
-            # This flag determines whether we load the prompt (i.e. the task instruction) from the
-            # ``task`` field in the LeRobot dataset. The recommended setting is True.
-            prompt_from_task=True,
-        ),
-    ),
-    # Load the pi0 base model checkpoint.
-    weight_loader=weight_loaders.CheckpointWeightLoader("gs://openpi-assets/checkpoints/pi0_base/params"),
-    num_train_steps=30_000,
-)
+| File | Description |
+|---|---|
+| `states.npy` | Shape `(T, 7)` — 6 joint angles + 1 gripper position |
+| `actions.npy` | Shape `(T, 7)` — 6 joint targets + 1 gripper command |
+| `base_rgb_*.png` | Third-person camera frames |
+| `wrist_rgb_*.png` | Wrist camera frames |
+| `task.txt` | Language instruction for the episode |
+
+## Step 2 — Compute normalization statistics
+
+```bash
+uv run scripts/compute_norm_stats.py --config pi0_ur5
 ```
 
+## Step 3 — Fine-tune
 
+Full fine-tuning with pi0:
 
+```bash
+uv run scripts/train.py --config pi0_ur5
+```
 
+LoRA fine-tuning (lower GPU memory):
 
+```bash
+uv run scripts/train.py --config pi0_ur5_low_mem_finetune
+```
+
+Fine-tuning with pi0-FAST:
+
+```bash
+uv run scripts/train.py --config pi0_fast_ur5
+```
+
+Before running, set `repo_id` in the chosen config inside `src/openpi/training/config.py` to
+point to your dataset.
+
+## Step 4 — Serve the policy
+
+```bash
+uv run scripts/serve_policy.py policy:checkpoint --policy.config pi0_ur5 --policy.dir ./checkpoints/pi0_ur5/<run_name>/
+```
+
+## Adapting to a different robot
+
+`UR5Inputs`, `UR5Outputs`, and `LeRobotUR5DataConfig` are designed to be easy to copy and
+modify for other single-arm robots. See `src/openpi/policies/libero_policy.py` for detailed
+inline comments explaining each part of the transform interface.

--- a/examples/ur5/convert_ur5_data_to_lerobot.py
+++ b/examples/ur5/convert_ur5_data_to_lerobot.py
@@ -1,0 +1,125 @@
+"""
+Minimal example script for converting a UR5 dataset to LeRobot format.
+
+This script assumes your raw UR5 data is stored as a directory of episodes,
+where each episode is a directory containing:
+  - A sequence of RGB images from the base camera (base_rgb_*.png or base_rgb_*.jpg)
+  - A sequence of RGB images from the wrist camera (wrist_rgb_*.png or wrist_rgb_*.jpg)
+  - A numpy file (states.npy) of shape (T, 7): 6 joint angles + 1 gripper position
+  - A numpy file (actions.npy) of shape (T, 7): 6 joint angle targets + 1 gripper command
+  - A text file (task.txt) containing the task description (language instruction)
+
+Adapt the loading logic below to match your actual data format.
+
+Usage:
+    uv run examples/ur5/convert_ur5_data_to_lerobot.py --data_dir /path/to/ur5_data
+
+To push to the Hugging Face Hub:
+    uv run examples/ur5/convert_ur5_data_to_lerobot.py --data_dir /path/to/ur5_data --push_to_hub
+"""
+
+import pathlib
+import shutil
+
+from lerobot.common.datasets.lerobot_dataset import HF_LEROBOT_HOME
+from lerobot.common.datasets.lerobot_dataset import LeRobotDataset
+import numpy as np
+from PIL import Image
+import tyro
+
+REPO_NAME = "your_hf_username/ur5_dataset"  # Change to your Hugging Face repo id
+
+
+def main(data_dir: str, *, push_to_hub: bool = False) -> None:
+    data_path = pathlib.Path(data_dir)
+    output_path = HF_LEROBOT_HOME / REPO_NAME
+    if output_path.exists():
+        shutil.rmtree(output_path)
+
+    # Create the LeRobot dataset.
+    # The feature names here must match the keys used in the repack transform defined in
+    # LeRobotUR5DataConfig (src/openpi/training/config.py).
+    dataset = LeRobotDataset.create(
+        repo_id=REPO_NAME,
+        robot_type="ur5",
+        fps=10,
+        features={
+            "base_rgb": {
+                "dtype": "image",
+                "shape": (224, 224, 3),
+                "names": ["height", "width", "channel"],
+            },
+            "wrist_rgb": {
+                "dtype": "image",
+                "shape": (224, 224, 3),
+                "names": ["height", "width", "channel"],
+            },
+            "joints": {
+                "dtype": "float32",
+                "shape": (6,),
+                "names": ["joints"],
+            },
+            "gripper": {
+                "dtype": "float32",
+                "shape": (1,),
+                "names": ["gripper"],
+            },
+            "actions": {
+                "dtype": "float32",
+                "shape": (7,),
+                "names": ["actions"],
+            },
+        },
+        image_writer_threads=10,
+        image_writer_processes=5,
+    )
+
+    # Iterate over episodes. Each sub-directory of data_dir is one episode.
+    episode_dirs = sorted(p for p in data_path.iterdir() if p.is_dir())
+    if not episode_dirs:
+        raise ValueError(f"No episode directories found under {data_dir}")
+
+    for episode_dir in episode_dirs:
+        states = np.load(episode_dir / "states.npy")  # (T, 7)
+        actions = np.load(episode_dir / "actions.npy")  # (T, 7)
+        task = (episode_dir / "task.txt").read_text().strip()
+
+        base_images = sorted(episode_dir.glob("base_rgb_*"))
+        wrist_images = sorted(episode_dir.glob("wrist_rgb_*"))
+
+        num_steps = len(states)
+        assert len(base_images) == num_steps, (
+            f"Expected {num_steps} base images in {episode_dir}, got {len(base_images)}"
+        )
+        assert len(wrist_images) == num_steps, (
+            f"Expected {num_steps} wrist images in {episode_dir}, got {len(wrist_images)}"
+        )
+
+        for t in range(num_steps):
+            base_img = np.array(Image.open(base_images[t]).convert("RGB"))
+            wrist_img = np.array(Image.open(wrist_images[t]).convert("RGB"))
+
+            dataset.add_frame(
+                {
+                    "base_rgb": base_img,
+                    "wrist_rgb": wrist_img,
+                    "joints": states[t, :6].astype(np.float32),
+                    "gripper": states[t, 6:7].astype(np.float32),
+                    "actions": actions[t].astype(np.float32),
+                    "task": task,
+                }
+            )
+
+        dataset.save_episode()
+
+    if push_to_hub:
+        dataset.push_to_hub(
+            tags=["ur5", "manipulation"],
+            private=False,
+            push_videos=True,
+            license="apache-2.0",
+        )
+
+
+if __name__ == "__main__":
+    tyro.cli(main)

--- a/src/openpi/policies/ur5_policy.py
+++ b/src/openpi/policies/ur5_policy.py
@@ -1,0 +1,105 @@
+import dataclasses
+
+import einops
+import numpy as np
+
+from openpi import transforms
+from openpi.models import model as _model
+
+
+def make_ur5_example() -> dict:
+    """Creates a random input example for the UR5 policy.
+
+    The keys and shapes here reflect what the inference environment sends to the policy
+    server at runtime (i.e. after the repack transform has already been applied).
+    """
+    return {
+        "joints": np.random.rand(6).astype(np.float32),
+        "gripper": np.random.rand(1).astype(np.float32),
+        "base_rgb": np.random.randint(256, size=(224, 224, 3), dtype=np.uint8),
+        "wrist_rgb": np.random.randint(256, size=(224, 224, 3), dtype=np.uint8),
+        "prompt": "do something",
+    }
+
+
+def _parse_image(image) -> np.ndarray:
+    image = np.asarray(image)
+    if np.issubdtype(image.dtype, np.floating):
+        image = (255 * image).astype(np.uint8)
+    if image.shape[0] == 3:
+        image = einops.rearrange(image, "c h w -> h w c")
+    return image
+
+
+@dataclasses.dataclass(frozen=True)
+class UR5Inputs(transforms.DataTransformFn):
+    """Converts UR5 environment observations to the format expected by the model.
+
+    This class is used for both training (applied after the repack transform) and
+    inference (applied to the dict sent by the robot client). For your own robot,
+    copy this class and adjust the keys and dimensions to match your setup.
+
+    The UR5 has 6 revolute joints and a parallel-jaw gripper, giving a 7-dimensional
+    state and action space. It is equipped with one base (third-person) camera and one
+    wrist camera; there is no second wrist camera, so that image slot is zero-padded.
+    """
+
+    # Determines which model will be used. Do not change this for your own robot.
+    model_type: _model.ModelType = _model.ModelType.PI0
+
+    def __call__(self, data: dict) -> dict:
+        # Concatenate 6 joint angles and 1 gripper position into a 7-dim state vector.
+        # Modify the keys and slicing to match your robot's proprioceptive state.
+        state = np.concatenate([data["joints"], data["gripper"]])
+
+        # Possibly need to parse images to uint8 (H, W, C) since LeRobot stores images
+        # as float32 (C, H, W). This conversion is a no-op during policy inference, where
+        # images already arrive as uint8 (H, W, C).
+        # If your robot uses different key names, change "base_rgb" and "wrist_rgb" here.
+        base_image = _parse_image(data["base_rgb"])
+        wrist_image = _parse_image(data["wrist_rgb"])
+
+        # Do not change the output keys below — these are fixed by the model.
+        # Pi0 supports three image slots: one third-person view and two wrist views.
+        # If a slot is unused, fill it with zeros and set its mask to False (pi0) or
+        # True (pi0-FAST, which attends to all slots regardless of the mask).
+        inputs = {
+            "state": state,
+            "image": {
+                "base_0_rgb": base_image,
+                "left_wrist_0_rgb": wrist_image,
+                # UR5 has no right wrist camera; pad the slot with zeros.
+                "right_wrist_0_rgb": np.zeros_like(base_image),
+            },
+            "image_mask": {
+                "base_0_rgb": np.True_,
+                "left_wrist_0_rgb": np.True_,
+                # Mask the unused slot for pi0; pi0-FAST uses all slots.
+                "right_wrist_0_rgb": np.True_ if self.model_type == _model.ModelType.PI0_FAST else np.False_,
+            },
+        }
+
+        # Actions are only present during training, not inference.
+        if "actions" in data:
+            inputs["actions"] = data["actions"]
+
+        # Pass the language instruction through to the model.
+        # The output key must always be "prompt".
+        if "prompt" in data:
+            inputs["prompt"] = data["prompt"]
+
+        return inputs
+
+
+@dataclasses.dataclass(frozen=True)
+class UR5Outputs(transforms.DataTransformFn):
+    """Converts model output actions back to the UR5 action space.
+
+    This class is used for inference only. For your own robot, replace ``7`` with
+    the number of action dimensions your robot actually uses.
+    """
+
+    def __call__(self, data: dict) -> dict:
+        # The model produces actions padded to its full internal action_dim.
+        # Slice out the first 7 dimensions (6 joint targets + 1 gripper command).
+        return {"actions": np.asarray(data["actions"][:, :7])}

--- a/src/openpi/policies/ur5_policy_test.py
+++ b/src/openpi/policies/ur5_policy_test.py
@@ -1,0 +1,103 @@
+import numpy as np
+import pytest
+
+from openpi.models import model as _model
+from openpi.policies import ur5_policy
+
+
+def test_make_ur5_example():
+    example = ur5_policy.make_ur5_example()
+    assert example["joints"].shape == (6,)
+    assert example["gripper"].shape == (1,)
+    assert example["base_rgb"].shape == (224, 224, 3)
+    assert example["wrist_rgb"].shape == (224, 224, 3)
+    assert "prompt" in example
+
+
+@pytest.mark.parametrize("model_type", [_model.ModelType.PI0, _model.ModelType.PI0_FAST])
+def test_ur5_inputs_shapes(model_type):
+    transform = ur5_policy.UR5Inputs(model_type=model_type)
+    example = ur5_policy.make_ur5_example()
+    out = transform(example)
+
+    assert out["state"].shape == (7,)
+    assert out["image"]["base_0_rgb"].shape == (224, 224, 3)
+    assert out["image"]["left_wrist_0_rgb"].shape == (224, 224, 3)
+    assert out["image"]["right_wrist_0_rgb"].shape == (224, 224, 3)
+
+
+def test_ur5_inputs_image_mask_pi0():
+    transform = ur5_policy.UR5Inputs(model_type=_model.ModelType.PI0)
+    out = transform(ur5_policy.make_ur5_example())
+    assert out["image_mask"]["base_0_rgb"] == np.True_
+    assert out["image_mask"]["left_wrist_0_rgb"] == np.True_
+    # Unused right-wrist slot should be masked out for pi0.
+    assert out["image_mask"]["right_wrist_0_rgb"] == np.False_
+
+
+def test_ur5_inputs_image_mask_pi0_fast():
+    transform = ur5_policy.UR5Inputs(model_type=_model.ModelType.PI0_FAST)
+    out = transform(ur5_policy.make_ur5_example())
+    # pi0-FAST attends to all image slots.
+    assert out["image_mask"]["right_wrist_0_rgb"] == np.True_
+
+
+def test_ur5_inputs_right_wrist_is_zeros():
+    transform = ur5_policy.UR5Inputs(model_type=_model.ModelType.PI0)
+    out = transform(ur5_policy.make_ur5_example())
+    assert np.all(out["image"]["right_wrist_0_rgb"] == 0)
+
+
+def test_ur5_inputs_state_concatenation():
+    transform = ur5_policy.UR5Inputs(model_type=_model.ModelType.PI0)
+    joints = np.array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6], dtype=np.float32)
+    gripper = np.array([0.7], dtype=np.float32)
+    data = {
+        "joints": joints,
+        "gripper": gripper,
+        "base_rgb": np.zeros((224, 224, 3), dtype=np.uint8),
+        "wrist_rgb": np.zeros((224, 224, 3), dtype=np.uint8),
+    }
+    out = transform(data)
+    np.testing.assert_array_equal(out["state"], np.array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7]))
+
+
+def test_ur5_inputs_image_conversion_from_float_chw():
+    """Images stored as float32 (C, H, W) by LeRobot should be converted to uint8 (H, W, C)."""
+    transform = ur5_policy.UR5Inputs(model_type=_model.ModelType.PI0)
+    float_chw = np.random.rand(3, 224, 224).astype(np.float32)
+    data = {
+        "joints": np.zeros(6, dtype=np.float32),
+        "gripper": np.zeros(1, dtype=np.float32),
+        "base_rgb": float_chw,
+        "wrist_rgb": float_chw,
+    }
+    out = transform(data)
+    img = out["image"]["base_0_rgb"]
+    assert img.dtype == np.uint8
+    assert img.shape == (224, 224, 3)
+
+
+def test_ur5_inputs_actions_passthrough():
+    transform = ur5_policy.UR5Inputs(model_type=_model.ModelType.PI0)
+    actions = np.random.rand(10, 7).astype(np.float32)
+    data = {**ur5_policy.make_ur5_example(), "actions": actions}
+    out = transform(data)
+    np.testing.assert_array_equal(out["actions"], actions)
+
+
+def test_ur5_inputs_no_actions_key_absent():
+    transform = ur5_policy.UR5Inputs(model_type=_model.ModelType.PI0)
+    data = ur5_policy.make_ur5_example()
+    data.pop("actions", None)
+    out = transform(data)
+    assert "actions" not in out
+
+
+def test_ur5_outputs_slices_seven_dims():
+    transform = ur5_policy.UR5Outputs()
+    # Simulate model output padded to a larger action_dim (e.g. 32).
+    padded = np.random.rand(10, 32).astype(np.float32)
+    out = transform({"actions": padded})
+    assert out["actions"].shape == (10, 7)
+    np.testing.assert_array_equal(out["actions"], padded[:, :7])

--- a/src/openpi/training/config.py
+++ b/src/openpi/training/config.py
@@ -20,6 +20,7 @@ import openpi.models.tokenizer as _tokenizer
 import openpi.policies.aloha_policy as aloha_policy
 import openpi.policies.droid_policy as droid_policy
 import openpi.policies.libero_policy as libero_policy
+import openpi.policies.ur5_policy as ur5_policy
 import openpi.shared.download as _download
 import openpi.shared.normalize as _normalize
 import openpi.training.droid_rlds_dataset as droid_rlds_dataset
@@ -347,6 +348,55 @@ class LeRobotLiberoDataConfig(DataConfigFactory):
         model_transforms = ModelTransformFactory()(model_config)
 
         # We return all data transforms for training and inference. No need to change anything here.
+        return dataclasses.replace(
+            self.create_base_config(assets_dirs, model_config),
+            repack_transforms=repack_transform,
+            data_transforms=data_transforms,
+            model_transforms=model_transforms,
+        )
+
+
+@dataclasses.dataclass(frozen=True)
+class LeRobotUR5DataConfig(DataConfigFactory):
+    """Data config for fine-tuning on UR5 datasets stored in LeRobot format.
+
+    The UR5 has 6 revolute joints and a parallel-jaw gripper (7-dim state/action),
+    one base (third-person) camera, and one wrist camera.
+    """
+
+    @override
+    def create(self, assets_dirs: pathlib.Path, model_config: _model.BaseModelConfig) -> DataConfig:
+        # Remap LeRobot dataset keys to the keys expected by the inference environment.
+        # Modify the left-hand side values to match your dataset's feature names.
+        repack_transform = _transforms.Group(
+            inputs=[
+                _transforms.RepackTransform(
+                    {
+                        "base_rgb": "image",
+                        "wrist_rgb": "wrist_image",
+                        "joints": "joints",
+                        "gripper": "gripper",
+                        "prompt": "prompt",
+                    }
+                )
+            ]
+        )
+
+        data_transforms = _transforms.Group(
+            inputs=[ur5_policy.UR5Inputs(model_type=model_config.model_type)],
+            outputs=[ur5_policy.UR5Outputs()],
+        )
+
+        # UR5 datasets typically store absolute joint-angle targets, so we convert
+        # the 6 joint dims to deltas and leave the gripper (7th dim) absolute.
+        delta_action_mask = _transforms.make_bool_mask(6, -1)
+        data_transforms = data_transforms.push(
+            inputs=[_transforms.DeltaActions(delta_action_mask)],
+            outputs=[_transforms.AbsoluteActions(delta_action_mask)],
+        )
+
+        model_transforms = ModelTransformFactory()(model_config)
+
         return dataclasses.replace(
             self.create_base_config(assets_dirs, model_config),
             repack_transforms=repack_transform,
@@ -915,6 +965,57 @@ _CONFIGS = [
         weight_loader=weight_loaders.CheckpointWeightLoader("gs://openpi-assets/checkpoints/pi05_droid/params"),
         num_train_steps=20_000,
         batch_size=32,
+    ),
+    #
+    # Fine-tuning UR5 configs.
+    #
+    TrainConfig(
+        name="pi0_ur5",
+        model=pi0_config.Pi0Config(),
+        data=LeRobotUR5DataConfig(
+            repo_id="your_hf_username/ur5_dataset",
+            assets=AssetsConfig(
+                # Reuse normalization stats from the pi0 base model checkpoint.
+                assets_dir="gs://openpi-assets/checkpoints/pi0_base/assets",
+                asset_id="ur5e",
+            ),
+            base_config=DataConfig(prompt_from_task=True),
+        ),
+        weight_loader=weight_loaders.CheckpointWeightLoader("gs://openpi-assets/checkpoints/pi0_base/params"),
+        num_train_steps=30_000,
+    ),
+    TrainConfig(
+        name="pi0_ur5_low_mem_finetune",
+        model=pi0_config.Pi0Config(paligemma_variant="gemma_2b_lora", action_expert_variant="gemma_300m_lora"),
+        data=LeRobotUR5DataConfig(
+            repo_id="your_hf_username/ur5_dataset",
+            assets=AssetsConfig(
+                assets_dir="gs://openpi-assets/checkpoints/pi0_base/assets",
+                asset_id="ur5e",
+            ),
+            base_config=DataConfig(prompt_from_task=True),
+        ),
+        weight_loader=weight_loaders.CheckpointWeightLoader("gs://openpi-assets/checkpoints/pi0_base/params"),
+        num_train_steps=30_000,
+        freeze_filter=pi0_config.Pi0Config(
+            paligemma_variant="gemma_2b_lora", action_expert_variant="gemma_300m_lora"
+        ).get_freeze_filter(),
+        ema_decay=None,
+    ),
+    TrainConfig(
+        name="pi0_fast_ur5",
+        # action_dim=7 (6 joints + 1 gripper), action_horizon=10, max_token_len=180 for single-arm robots.
+        model=pi0_fast.Pi0FASTConfig(action_dim=7, action_horizon=10, max_token_len=180),
+        data=LeRobotUR5DataConfig(
+            repo_id="your_hf_username/ur5_dataset",
+            assets=AssetsConfig(
+                assets_dir="gs://openpi-assets/checkpoints/pi0_fast_base/assets",
+                asset_id="ur5e",
+            ),
+            base_config=DataConfig(prompt_from_task=True),
+        ),
+        weight_loader=weight_loaders.CheckpointWeightLoader("gs://openpi-assets/checkpoints/pi0_fast_base/params"),
+        num_train_steps=30_000,
     ),
     #
     # ALOHA Sim configs. This config is used to demonstrate how to train on a simple simulated environment.


### PR DESCRIPTION
This PR implements the UR5 fine-tuning example that was previously outlined in `examples/ur5/README.md` as pseudocode.

## Changes

- Add `UR5Inputs` and `UR5Outputs` transform classes in `src/openpi/policies/ur5_policy.py`, mapping UR5 observations (6 joints + 1 gripper, base and wrist cameras) to the format expected by pi0 / pi0-FAST / pi0.5
- Add `LeRobotUR5DataConfig` and three ready-to-use training configs in `src/openpi/training/config.py`: `pi0_ur5` (full fine-tune), `pi0_ur5_low_mem_finetune` (LoRA), `pi0_fast_ur5`
- Add `examples/ur5/convert_ur5_data_to_lerobot.py` for converting raw UR5 recordings to LeRobot dataset format
- Add unit tests covering state concatenation, image format conversion (float32 CHW → uint8 HWC), image masks, and action slicing
- Rewrite `examples/ur5/README.md` with step-by-step usage instructions

## Bug fixes in original README outline

- `create_base_config()` was missing the required `model_config` argument
- `UR5Inputs` constructor referenced a non-existent `action_dim` field (padding is handled by `PadStatesAndActions` in `ModelTransformFactory`)
