### PR TITLE
Remove conflicting `tree` dependency from openpi-client

### DIFF
--- a/packages/openpi-client/pyproject.toml
+++ b/packages/openpi-client/pyproject.toml
@@ -7,7 +7,6 @@ dependencies = [
     "msgpack>=1.0.5",
     "numpy>=1.22.4,<2.0.0",
     "pillow>=9.0.0",
-    "tree>=0.2.4",
     "websockets>=11.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -3197,7 +3197,6 @@ dependencies = [
     { name = "msgpack" },
     { name = "numpy" },
     { name = "pillow" },
-    { name = "tree" },
     { name = "websockets" },
 ]
 
@@ -3212,7 +3211,6 @@ requires-dist = [
     { name = "msgpack", specifier = ">=1.0.5" },
     { name = "numpy", specifier = ">=1.22.4,<2.0.0" },
     { name = "pillow", specifier = ">=9.0.0" },
-    { name = "tree", specifier = ">=0.2.4" },
     { name = "websockets", specifier = ">=11.0" },
 ]
 
@@ -4566,15 +4564,6 @@ wheels = [
 ]
 
 [[package]]
-name = "svgwrite"
-version = "1.4.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/16/c1/263d4e93b543390d86d8eb4fc23d9ce8a8d6efd146f9427364109004fa9b/svgwrite-1.4.3.zip", hash = "sha256:a8fbdfd4443302a6619a7f76bc937fc683daf2628d9b737c891ec08b8ce524c3", size = 189516, upload-time = "2022-07-14T14:05:26.107Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/15/640e399579024a6875918839454025bb1d5f850bb70d96a11eabb644d11c/svgwrite-1.4.3-py3-none-any.whl", hash = "sha256:bb6b2b5450f1edbfa597d924f9ac2dd099e625562e492021d7dd614f65f8a22d", size = 67122, upload-time = "2022-07-14T14:05:24.459Z" },
-]
-
-[[package]]
 name = "sympy"
 version = "1.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4994,18 +4983,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/4c/67/80f51466ec447028f
 wheels = [
     { url = "https://files.pythonhosted.org/packages/96/88/beb33a79a382fcd2aed0be5222bdc47f41e4bfe7aaa90ae1374f1d8ea2af/transformers-4.53.2-py3-none-any.whl", hash = "sha256:db8f4819bb34f000029c73c3c557e7d06fc1b8e612ec142eecdae3947a9c78bf", size = 10826609, upload-time = "2025-07-11T12:39:05.461Z" },
 ]
-
-[[package]]
-name = "tree"
-version = "0.2.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "pillow" },
-    { name = "setuptools" },
-    { name = "svgwrite" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/29/3f/63cbed2909786f0e5ac30a4ae5791ad597c6b5fec7167e161c55bba511ce/Tree-0.2.4.tar.gz", hash = "sha256:f84d8ec9bf50dd69f551da78925a23d110864e7706551f590cdade27646f7883", size = 6489, upload-time = "2018-07-03T20:49:29.918Z" }
 
 [[package]]
 name = "treescope"


### PR DESCRIPTION
## Summary

  This removes the conflicting `tree>=0.2.4` dependency from `packages/openpi-client`.

  ## Why

  `openpi-client` imports `tree` for `tree.map_structure`, but that import is provided by `dm-tree`, which is already declared as a dependency.

  The separate PyPI package named `tree` can conflict with `dm-tree` because both use the `tree` import name. This was causing `openpi-client` imports to resolve to the wrong package depending on install order/environment.

  ## Changes

  - remove `tree>=0.2.4` from `packages/openpi-client/pyproject.toml`
  - update `uv.lock` (removes the transitive `svgwrite` lock entry)

  ## Validation

  - ran `uv lock --check`
  - ran `uv run --project packages/openpi-client --with pytest pytest packages/openpi-client`
  - ran `uv run --no-sync ruff check --fix packages/openpi-client`
  - ran `uv run --no-sync ruff format packages/openpi-client`

  ## Notes

  This keeps `dm-tree` unchanged because it is the package that provides the `tree.map_structure` API used by `openpi-client`.