### PR TITLE
Add explicit batched inference for PyTorch pi0 policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,14 @@ policy = policy_config.create_trained_policy(config, checkpoint_dir)
 action_chunk = policy.infer(example)["actions"]
 ```
 
+For vectorized PyTorch inference, pass a sequence of per-environment observations to `infer_batch`. The same input and output transforms are applied per observation, then the PyTorch model is sampled once with a leading batch dimension:
+
+```python
+examples = [example0, example1]
+batched_action_chunks = policy.infer_batch(examples)["actions"]
+assert batched_action_chunks.shape[0] == len(examples)
+```
+
 ### Policy Server with PyTorch
 
 The policy server works identically with PyTorch models - just point to the converted checkpoint directory:

--- a/docs/remote_inference.md
+++ b/docs/remote_inference.md
@@ -69,3 +69,12 @@ for step in range(num_steps):
 ```
 
 Here, the `host` and `port` arguments specify the IP address and port of the remote policy server. You can also specify these as command-line arguments to your robot code, or hard-code them in your robot codebase. The `observation` is a dictionary of observations and the prompt, following the specification of the policy inputs for the policy you are serving. We have concrete examples of how to construct this dictionary for different environments in the [simple client example](../examples/simple_client/main.py).
+
+For vectorized environments, send an explicit batch of per-environment observations. This returns action chunks with shape `(batch_size, action_horizon, action_dim)`. Batched requests are explicit so existing single-environment clients keep the same `(action_horizon, action_dim)` result shape from `client.infer(...)`.
+
+```python
+observations = [make_observation(env_index) for env_index in range(num_envs)]
+action_chunks = client.infer_batch(observations)["actions"]
+```
+
+`ActionChunkBroker` is intended for single-environment action chunking. Batched environments should index the returned batch themselves, or use a separate per-environment chunking layer.

--- a/packages/openpi-client/pyproject.toml
+++ b/packages/openpi-client/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "msgpack>=1.0.5",
     "numpy>=1.22.4,<2.0.0",
     "pillow>=9.0.0",
+    "typing-extensions>=4.12.2",
     "websockets>=11.0",
 ]
 

--- a/packages/openpi-client/src/openpi_client/base_policy.py
+++ b/packages/openpi-client/src/openpi_client/base_policy.py
@@ -1,11 +1,20 @@
 import abc
 from typing import Dict
+from typing import Sequence
 
 
 class BasePolicy(abc.ABC):
     @abc.abstractmethod
     def infer(self, obs: Dict) -> Dict:
         """Infer actions from observations."""
+
+    def infer_batch(self, obs_batch: Sequence[Dict]) -> Dict:
+        """Infer actions from a batch of observations.
+
+        Policies with correct batched semantics should override this method. The base implementation deliberately does
+        not loop over `infer`, since stateful wrappers may need per-environment state to batch safely.
+        """
+        raise NotImplementedError(f"{type(self).__name__} does not support batched inference")
 
     def reset(self) -> None:
         """Reset the policy to its initial state."""

--- a/packages/openpi-client/src/openpi_client/websocket_client_policy.py
+++ b/packages/openpi-client/src/openpi_client/websocket_client_policy.py
@@ -1,6 +1,6 @@
 import logging
 import time
-from typing import Dict, Optional, Tuple
+from typing import Dict, Optional, Sequence, Tuple
 
 from typing_extensions import override
 import websockets.sync.client
@@ -46,6 +46,23 @@ class WebsocketClientPolicy(_base_policy.BasePolicy):
     @override
     def infer(self, obs: Dict) -> Dict:  # noqa: UP006
         data = self._packer.pack(obs)
+        return self._send_and_recv(data)
+
+    @override
+    def infer_batch(self, obs_batch: Sequence[Dict]) -> Dict:  # noqa: UP006
+        if isinstance(obs_batch, (dict, str, bytes)):
+            raise TypeError("obs_batch must be a non-empty sequence of observation dictionaries")
+
+        obs_batch = list(obs_batch)
+        if not obs_batch:
+            raise ValueError("obs_batch must contain at least one observation")
+        if not all(isinstance(obs, dict) for obs in obs_batch):
+            raise TypeError("obs_batch must contain only observation dictionaries")
+
+        data = self._packer.pack({"batch": obs_batch})
+        return self._send_and_recv(data)
+
+    def _send_and_recv(self, data: bytes) -> Dict:
         self._ws.send(data)
         response = self._ws.recv()
         if isinstance(response, str):

--- a/packages/openpi-client/src/openpi_client/websocket_client_policy_test.py
+++ b/packages/openpi-client/src/openpi_client/websocket_client_policy_test.py
@@ -1,0 +1,56 @@
+import numpy as np
+import pytest
+
+from openpi_client import msgpack_numpy
+from openpi_client import websocket_client_policy
+
+
+class _FakeWebsocket:
+    def __init__(self, response):
+        self.response = response
+        self.sent = []
+
+    def send(self, data):
+        self.sent.append(msgpack_numpy.unpackb(data))
+
+    def recv(self):
+        return self.response
+
+
+def _make_client(response):
+    client = object.__new__(websocket_client_policy.WebsocketClientPolicy)
+    client._packer = msgpack_numpy.Packer()
+    client._ws = _FakeWebsocket(response)
+    return client
+
+
+def test_infer_batch_sends_explicit_batch_payload():
+    response = msgpack_numpy.packb({"actions": np.zeros((2, 3, 1), dtype=np.float32)})
+    client = _make_client(response)
+
+    result = client.infer_batch([{"state": np.asarray([1])}, {"state": np.asarray([2])}])
+
+    assert result["actions"].shape == (2, 3, 1)
+    assert len(client._ws.sent) == 1
+    assert set(client._ws.sent[0]) == {"batch"}
+    np.testing.assert_array_equal(client._ws.sent[0]["batch"][0]["state"], np.asarray([1]))
+    np.testing.assert_array_equal(client._ws.sent[0]["batch"][1]["state"], np.asarray([2]))
+
+
+def test_infer_batch_reuses_error_response_handling():
+    client = _make_client("traceback")
+
+    with pytest.raises(RuntimeError, match="Error in inference server"):
+        client.infer_batch([{"state": np.asarray([1])}])
+
+
+def test_infer_batch_validates_input():
+    response = msgpack_numpy.packb({})
+    client = _make_client(response)
+
+    with pytest.raises(ValueError, match="at least one observation"):
+        client.infer_batch([])
+    with pytest.raises(TypeError, match="sequence of observation dictionaries"):
+        client.infer_batch({"state": np.asarray([1])})
+    with pytest.raises(TypeError, match="only observation dictionaries"):
+        client.infer_batch([{"state": np.asarray([1])}, "bad"])

--- a/src/openpi/policies/policy.py
+++ b/src/openpi/policies/policy.py
@@ -66,26 +66,30 @@ class Policy(BasePolicy):
 
     @override
     def infer(self, obs: dict, *, noise: np.ndarray | None = None) -> dict:  # type: ignore[misc]
-        # Make a copy since transformations may modify the inputs in place.
-        inputs = jax.tree.map(lambda x: x, obs)
-        inputs = self._input_transform(inputs)
-        if not self._is_pytorch_model:
-            # Make a batch and convert to jax.Array.
-            inputs = jax.tree.map(lambda x: jnp.asarray(x)[np.newaxis, ...], inputs)
-            self._rng, sample_rng_or_pytorch_device = jax.random.split(self._rng)
-        else:
-            # Convert inputs to PyTorch tensors and move to correct device
-            inputs = jax.tree.map(lambda x: torch.from_numpy(np.array(x)).to(self._pytorch_device)[None, ...], inputs)
-            sample_rng_or_pytorch_device = self._pytorch_device
+        return self._infer_batch([obs], noise=noise, batched=False)
 
-        # Prepare kwargs for sample_actions
+    @override
+    def infer_batch(self, obs_batch: Sequence[dict], *, noise: np.ndarray | None = None) -> dict:
+        obs_batch = _validate_obs_batch(obs_batch)
+        return self._infer_batch(obs_batch, noise=noise, batched=True)
+
+    def _infer_batch(self, obs_batch: Sequence[dict], *, noise: np.ndarray | None, batched: bool) -> dict:
+        # Make a copy since transformations may modify the inputs in place.
+        transformed = [self._input_transform(_copy_tree(obs)) for obs in obs_batch]
+
+        inputs = _stack_trees(transformed)
+        batch_size = len(transformed)
+
+        if self._is_pytorch_model:
+            inputs = jax.tree.map(lambda x: torch.from_numpy(np.array(x)).to(self._pytorch_device), inputs)
+            sample_rng_or_pytorch_device = self._pytorch_device
+        else:
+            inputs = jax.tree.map(jnp.asarray, inputs)
+            self._rng, sample_rng_or_pytorch_device = jax.random.split(self._rng)
+
         sample_kwargs = dict(self._sample_kwargs)
         if noise is not None:
-            noise = torch.from_numpy(noise).to(self._pytorch_device) if self._is_pytorch_model else jnp.asarray(noise)
-
-            if noise.ndim == 2:  # If noise is (action_horizon, action_dim), add batch dimension
-                noise = noise[None, ...]  # Make it (1, action_horizon, action_dim)
-            sample_kwargs["noise"] = noise
+            sample_kwargs["noise"] = self._prepare_noise(noise, batch_size=batch_size, batched=batched)
 
         observation = _model.Observation.from_dict(inputs)
         start_time = time.monotonic()
@@ -94,16 +98,49 @@ class Policy(BasePolicy):
             "actions": self._sample_actions(sample_rng_or_pytorch_device, observation, **sample_kwargs),
         }
         model_time = time.monotonic() - start_time
-        if self._is_pytorch_model:
-            outputs = jax.tree.map(lambda x: np.asarray(x[0, ...].detach().cpu()), outputs)
-        else:
-            outputs = jax.tree.map(lambda x: np.asarray(x[0, ...]), outputs)
 
-        outputs = self._output_transform(outputs)
+        outputs = _to_numpy_tree(outputs, is_pytorch=self._is_pytorch_model)
+        outputs = self._apply_output_transforms_batch(outputs, batch_size=batch_size)
+        if not batched:
+            outputs = jax.tree.map(lambda x: x[0, ...], outputs)
+
         outputs["policy_timing"] = {
             "infer_ms": model_time * 1000,
         }
+        if batched:
+            outputs["policy_timing"]["batch_size"] = batch_size
         return outputs
+
+    def _prepare_noise(self, noise: np.ndarray, *, batch_size: int, batched: bool):
+        noise = (
+            torch.from_numpy(np.asarray(noise)).to(self._pytorch_device)
+            if self._is_pytorch_model
+            else jnp.asarray(noise)
+        )
+
+        if noise.ndim == 2:
+            if batched:
+                raise ValueError(
+                    "Batched noise must have shape (batch_size, action_horizon, action_dim); "
+                    f"got unbatched noise with shape {tuple(noise.shape)}"
+                )
+            return noise[None, ...]
+
+        if noise.ndim != 3:
+            raise ValueError(
+                "Noise must have shape (action_horizon, action_dim) for infer or "
+                f"(batch_size, action_horizon, action_dim) for infer_batch; got shape {tuple(noise.shape)}"
+            )
+
+        if noise.shape[0] != batch_size:
+            raise ValueError(f"Noise batch size {noise.shape[0]} does not match observation batch size {batch_size}")
+
+        return noise
+
+    def _apply_output_transforms_batch(self, outputs: dict, *, batch_size: int) -> dict:
+        output_batch = [_index_tree(outputs, i) for i in range(batch_size)]
+        transformed = [self._output_transform(output) for output in output_batch]
+        return _stack_trees(transformed)
 
     @property
     def metadata(self) -> dict[str, Any]:
@@ -124,12 +161,60 @@ class PolicyRecorder(_base_policy.BasePolicy):
     @override
     def infer(self, obs: dict) -> dict:  # type: ignore[misc]
         results = self._policy.infer(obs)
+        self._record({"inputs": obs, "outputs": results})
+        return results
 
-        data = {"inputs": obs, "outputs": results}
+    @override
+    def infer_batch(self, obs_batch: Sequence[dict]) -> dict:
+        results = self._policy.infer_batch(obs_batch)
+        self._record({"inputs": obs_batch, "outputs": results})
+        return results
+
+    def _record(self, data: dict) -> None:
         data = flax.traverse_util.flatten_dict(data, sep="/")
 
         output_path = self._record_dir / f"step_{self._record_step}"
         self._record_step += 1
 
         np.save(output_path, np.asarray(data))
-        return results
+
+
+def _validate_obs_batch(obs_batch: Sequence[dict]) -> list[dict]:
+    if isinstance(obs_batch, (dict, str, bytes)) or not isinstance(obs_batch, Sequence):
+        raise TypeError("obs_batch must be a non-empty sequence of observation dictionaries")
+
+    obs_batch = list(obs_batch)
+    if not obs_batch:
+        raise ValueError("obs_batch must contain at least one observation")
+    if not all(isinstance(obs, dict) for obs in obs_batch):
+        raise TypeError("obs_batch must contain only observation dictionaries")
+    return obs_batch
+
+
+def _copy_tree(tree):
+    return jax.tree.map(lambda x: x.copy() if isinstance(x, np.ndarray) else x, tree)
+
+
+def _stack_trees(trees: Sequence[dict]) -> dict:
+    try:
+        return jax.tree.map(_stack_leaves, *trees)
+    except Exception as e:
+        raise ValueError(
+            "Could not stack policy batch; all observations must have matching structure and shapes"
+        ) from e
+
+
+def _stack_leaves(*leaves):
+    if isinstance(leaves[0], (str, bytes)):
+        raise TypeError("String leaves cannot be batched; tokenize prompts before stacking")
+    return np.stack(leaves, axis=0)
+
+
+def _index_tree(tree: dict, index: int) -> dict:
+    return jax.tree.map(lambda x: x[index, ...], tree)
+
+
+def _to_numpy_tree(tree: dict, *, is_pytorch: bool) -> dict:
+    if is_pytorch:
+        return jax.tree.map(lambda x: np.asarray(x.detach().cpu()), tree)
+    return jax.tree.map(np.asarray, tree)

--- a/src/openpi/policies/policy_test.py
+++ b/src/openpi/policies/policy_test.py
@@ -1,9 +1,173 @@
+import numpy as np
 from openpi_client import action_chunk_broker
+from openpi_client import base_policy
 import pytest
+import torch
 
 from openpi.policies import aloha_policy
+from openpi.policies import policy as _policy
 from openpi.policies import policy_config as _policy_config
 from openpi.training import config as _config
+
+
+class _FakeTorchModel:
+    action_horizon = 3
+    action_dim = 4
+
+    def __init__(self):
+        self.sample_calls = 0
+
+    def to(self, device):
+        self.device = device
+        return self
+
+    def eval(self):
+        self.eval_called = True
+        return self
+
+    def sample_actions(self, device, observation, noise=None, **kwargs):
+        del kwargs
+        self.sample_calls += 1
+        assert device == self.device
+        assert observation.state.ndim == 2
+        if noise is not None:
+            return noise
+        row_values = observation.state[:, :1].to(torch.float32)
+        return row_values[:, None, :].expand(-1, self.action_horizon, self.action_dim).clone()
+
+
+def _make_model_obs(value: float) -> dict:
+    return {
+        "image": {"base_0_rgb": np.zeros((2, 2, 3), dtype=np.float32)},
+        "image_mask": {"base_0_rgb": np.True_},
+        "state": np.asarray([value, 0.0], dtype=np.float32),
+    }
+
+
+class _CountingInputTransform:
+    def __init__(self):
+        self.calls = 0
+
+    def __call__(self, data):
+        self.calls += 1
+        assert data["state"].ndim == 1
+        return data
+
+
+class _TrimOutputTransform:
+    def __init__(self):
+        self.calls = 0
+
+    def __call__(self, data):
+        self.calls += 1
+        assert data["actions"].ndim == 2
+        return {"actions": data["actions"][:, :2]}
+
+
+def _make_policy(*, transforms=(), output_transforms=()):
+    model = _FakeTorchModel()
+    policy = _policy.Policy(
+        model,
+        transforms=transforms,
+        output_transforms=output_transforms,
+        is_pytorch=True,
+        pytorch_device="cpu",
+    )
+    return policy, model
+
+
+def test_infer_keeps_single_observation_shape():
+    policy, model = _make_policy()
+
+    result = policy.infer(_make_model_obs(5.0))
+
+    assert result["actions"].shape == (model.action_horizon, model.action_dim)
+    np.testing.assert_allclose(result["actions"], 5.0)
+    assert model.sample_calls == 1
+
+
+def test_infer_batch_keeps_batch_dimension_and_uses_one_model_call():
+    policy, model = _make_policy()
+
+    result = policy.infer_batch([_make_model_obs(5.0), _make_model_obs(7.0)])
+
+    assert result["actions"].shape == (2, model.action_horizon, model.action_dim)
+    np.testing.assert_allclose(result["actions"][0], 5.0)
+    np.testing.assert_allclose(result["actions"][1], 7.0)
+    assert result["policy_timing"]["batch_size"] == 2
+    assert model.sample_calls == 1
+
+
+def test_infer_batch_applies_transforms_per_sample():
+    input_transform = _CountingInputTransform()
+    output_transform = _TrimOutputTransform()
+    policy, model = _make_policy(transforms=[input_transform], output_transforms=[output_transform])
+
+    result = policy.infer_batch([_make_model_obs(1.0), _make_model_obs(2.0)])
+
+    assert result["actions"].shape == (2, model.action_horizon, 2)
+    assert input_transform.calls == 2
+    assert output_transform.calls == 2
+    assert model.sample_calls == 1
+
+
+def test_infer_batch_validates_observations_and_noise():
+    policy, model = _make_policy()
+    obs_batch = [_make_model_obs(1.0), _make_model_obs(2.0)]
+
+    noise = np.ones((2, model.action_horizon, model.action_dim), dtype=np.float32)
+    result = policy.infer_batch(obs_batch, noise=noise)
+    np.testing.assert_allclose(result["actions"], noise)
+
+    singleton_noise = np.ones((model.action_horizon, model.action_dim), dtype=np.float32)
+    result = policy.infer(_make_model_obs(1.0), noise=singleton_noise)
+    np.testing.assert_allclose(result["actions"], singleton_noise)
+
+    with pytest.raises(ValueError, match="obs_batch must contain at least one observation"):
+        policy.infer_batch([])
+    with pytest.raises(TypeError, match="obs_batch must be a non-empty sequence"):
+        policy.infer_batch({"not": "a list"})  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="obs_batch must contain only observation dictionaries"):
+        policy.infer_batch([_make_model_obs(1.0), "bad"])  # type: ignore[list-item]
+    with pytest.raises(ValueError, match="Batched noise must have shape"):
+        policy.infer_batch(obs_batch, noise=singleton_noise)
+    with pytest.raises(ValueError, match="Noise batch size 1 does not match observation batch size 2"):
+        policy.infer_batch(obs_batch, noise=noise[:1])
+
+
+class _InferOnlyPolicy(base_policy.BasePolicy):
+    def infer(self, obs):
+        del obs
+        return {"actions": np.zeros((2, 1), dtype=np.float32)}
+
+
+def test_base_policy_and_action_chunk_broker_do_not_fallback_to_sequential_batching():
+    with pytest.raises(NotImplementedError, match="does not support batched inference"):
+        _InferOnlyPolicy().infer_batch([{}])
+
+    broker = action_chunk_broker.ActionChunkBroker(_InferOnlyPolicy(), action_horizon=1)
+    with pytest.raises(NotImplementedError, match="does not support batched inference"):
+        broker.infer_batch([{}])
+
+
+class _BatchPolicy(_InferOnlyPolicy):
+    def __init__(self):
+        self.obs_batch = None
+
+    def infer_batch(self, obs_batch):
+        self.obs_batch = obs_batch
+        return {"actions": np.zeros((len(obs_batch), 2, 1), dtype=np.float32)}
+
+
+def test_policy_recorder_forwards_infer_batch(tmp_path):
+    inner = _BatchPolicy()
+    recorder = _policy.PolicyRecorder(inner, str(tmp_path))
+
+    result = recorder.infer_batch([{"x": np.asarray([1])}, {"x": np.asarray([2])}])
+
+    assert result["actions"].shape == (2, 2, 1)
+    assert inner.obs_batch is not None
+    assert (tmp_path / "step_0.npy").exists()
 
 
 @pytest.mark.manual

--- a/src/openpi/serving/websocket_policy_server.py
+++ b/src/openpi/serving/websocket_policy_server.py
@@ -58,7 +58,7 @@ class WebsocketPolicyServer:
                 obs = msgpack_numpy.unpackb(await websocket.recv())
 
                 infer_time = time.monotonic()
-                action = self._policy.infer(obs)
+                action = infer_policy_request(self._policy, obs)
                 infer_time = time.monotonic() - infer_time
 
                 action["server_timing"] = {
@@ -88,3 +88,9 @@ def _health_check(connection: _server.ServerConnection, request: _server.Request
         return connection.respond(http.HTTPStatus.OK, "OK\n")
     # Continue with the normal request handling.
     return None
+
+
+def infer_policy_request(policy: _base_policy.BasePolicy, request: dict) -> dict:
+    if isinstance(request, dict) and set(request.keys()) == {"batch"}:
+        return policy.infer_batch(request["batch"])
+    return policy.infer(request)

--- a/src/openpi/serving/websocket_policy_server_test.py
+++ b/src/openpi/serving/websocket_policy_server_test.py
@@ -1,0 +1,40 @@
+import numpy as np
+from openpi_client import base_policy
+
+from openpi.serving import websocket_policy_server
+
+
+class _FakePolicy(base_policy.BasePolicy):
+    def __init__(self):
+        self.infer_request = None
+        self.infer_batch_request = None
+
+    def infer(self, obs):
+        self.infer_request = obs
+        return {"mode": "single"}
+
+    def infer_batch(self, obs_batch):
+        self.infer_batch_request = obs_batch
+        return {"mode": "batch", "actions": np.zeros((len(obs_batch), 2, 1), dtype=np.float32)}
+
+
+def test_infer_policy_request_routes_explicit_batch():
+    policy = _FakePolicy()
+    request = {"batch": [{"state": np.asarray([1])}, {"state": np.asarray([2])}]}
+
+    result = websocket_policy_server.infer_policy_request(policy, request)
+
+    assert result["mode"] == "batch"
+    assert policy.infer_batch_request == request["batch"]
+    assert policy.infer_request is None
+
+
+def test_infer_policy_request_does_not_treat_batch_key_as_magic_when_other_keys_exist():
+    policy = _FakePolicy()
+    request = {"batch": np.asarray([1]), "state": np.asarray([2])}
+
+    result = websocket_policy_server.infer_policy_request(policy, request)
+
+    assert result["mode"] == "single"
+    assert policy.infer_request is request
+    assert policy.infer_batch_request is None

--- a/uv.lock
+++ b/uv.lock
@@ -3197,6 +3197,7 @@ dependencies = [
     { name = "msgpack" },
     { name = "numpy" },
     { name = "pillow" },
+    { name = "typing-extensions" },
     { name = "websockets" },
 ]
 
@@ -3211,6 +3212,7 @@ requires-dist = [
     { name = "msgpack", specifier = ">=1.0.5" },
     { name = "numpy", specifier = ">=1.22.4,<2.0.0" },
     { name = "pillow", specifier = ">=9.0.0" },
+    { name = "typing-extensions", specifier = ">=4.12.2" },
     { name = "websockets", specifier = ">=11.0" },
 ]
 


### PR DESCRIPTION
## Summary

Adds an explicit batched inference path for policy users and websocket clients. The new `Policy.infer_batch([...])` path applies existing input/output transforms per observation, stacks the transformed batch, and calls the model once with a leading batch dimension. Existing `infer(obs)` behavior and shapes are preserved.

This also adds `WebsocketClientPolicy.infer_batch([...])` using an explicit `{"batch": [...]}` request payload, plus server-side routing for that payload.

## Root Cause

Issue #765 asks whether the PyTorch `pi0` / `pi0.5` models support vectorized inference. The model core is batch-shaped, but the public policy/server path always treated incoming data as one observation: it transformed one dict, added a singleton batch dimension, sampled, and stripped index 0 from outputs. Passing already-batched observations therefore produced shapes like `[1, B, ...]` instead of true `[B, ...]` inference.

## Changes

- Add optional `BasePolicy.infer_batch` that raises by default instead of unsafe sequential fallback.
- Implement optimized `Policy.infer_batch` for true batched sampling while keeping `Policy.infer` singleton-compatible.
- Preserve per-sample transform semantics by applying input and output transforms around the model batch boundary.
- Add explicit websocket batch routing and client support.
- Forward batched calls through `PolicyRecorder`.
- Document local and remote vectorized inference usage.
- Add focused tests for batch shape preservation, one model call, transform behavior, noise validation, wrapper behavior, websocket request routing, and client payload handling.
- Add `typing-extensions` to `openpi-client` metadata because the client package already imports it.

## Validation

- `uv run --project packages/openpi-client pytest packages/openpi-client/src/openpi_client` -> 24 passed
- `uvx ruff check src/openpi/policies/policy.py src/openpi/policies/policy_test.py src/openpi/serving/websocket_policy_server.py src/openpi/serving/websocket_policy_server_test.py packages/openpi-client/src/openpi_client/base_policy.py packages/openpi-client/src/openpi_client/websocket_client_policy.py packages/openpi-client/src/openpi_client/websocket_client_policy_test.py`
- `uvx ruff format --check src/openpi/policies/policy.py src/openpi/policies/policy_test.py src/openpi/serving/websocket_policy_server.py src/openpi/serving/websocket_policy_server_test.py packages/openpi-client/src/openpi_client/base_policy.py packages/openpi-client/src/openpi_client/websocket_client_policy.py packages/openpi-client/src/openpi_client/websocket_client_policy_test.py`
- `python -m py_compile src/openpi/policies/policy.py src/openpi/policies/policy_test.py src/openpi/serving/websocket_policy_server.py src/openpi/serving/websocket_policy_server_test.py packages/openpi-client/src/openpi_client/base_policy.py packages/openpi-client/src/openpi_client/websocket_client_policy.py packages/openpi-client/src/openpi_client/websocket_client_policy_test.py`
- `uv lock --check`
- `git diff --check`

Note: root `uv run pytest src/openpi/policies/policy_test.py src/openpi/serving/websocket_policy_server_test.py` cannot run on macOS arm64 because `jax-cuda12-plugin==0.5.3` has no compatible wheel for this platform; it fails before test collection.

Addresses #765.