### PR TITLE
Fix stale rollout success state and preserve LIBERO replay videos

### DIFF
--- a/examples/libero/main.py
+++ b/examples/libero/main.py
@@ -99,7 +99,7 @@ def eval_libero(args: Args) -> None:
             # Setup
             t = 0
             replay_images = []
-
+            done = False
             logging.info(f"Starting episode {task_episodes+1}...")
             while t < max_steps + args.num_steps_wait:
                 try:
@@ -166,9 +166,8 @@ def eval_libero(args: Args) -> None:
 
             # Save a replay video of the episode
             suffix = "success" if done else "failure"
-            task_segment = task_description.replace(" ", "_")
             imageio.mimwrite(
-                pathlib.Path(args.video_out_path) / f"rollout_{task_segment}_{suffix}.mp4",
+                pathlib.Path(args.video_out_path) / f"rollout_task{task_id:02d}_ep{episode_idx:03d}_{suffix}.mp4",
                 [np.asarray(x) for x in replay_images],
                 fps=10,
             )


### PR DESCRIPTION
This PR makes two small improvements to `examples/libero/main.py`:

1. Fixes stale episode success state after exceptions
2. Prevents replay videos from being overwritten across episodes

**1. Reset episode success state**
`done` was not initialized before entering the episode loop, so if an exception occurs before env.step() runs, the previous episode's value carries over. This can cause a failed episode to be incorrectly saved and logged as a success. Fixed by adding `done = False` at the start of each episode.

**2. Preserve replay videos across episodes**
Replay videos were previously saved using filenames based only on task description and success/failure suffix, causing later episodes to overwrite earlier ones. This makes failure analysis unreliable, since a later success can overwrite an earlier failure video. Added `ep{episode_idx:03d}` to the filename so all rollout videos are preserved.

Neither change affects evaluation metrics or rollout behavior.
