### PR TITLE
Apply the same augmentation chain to all camera images

### DIFF
--- a/src/openpi/models/model.py
+++ b/src/openpi/models/model.py
@@ -169,15 +169,13 @@ def preprocess_observation(
             # Convert from [-1, 1] to [0, 1] for augmax.
             image = image / 2.0 + 0.5
 
-            transforms = []
-            if "wrist" not in key:
-                height, width = image.shape[1:3]
-                transforms += [
-                    augmax.RandomCrop(int(width * 0.95), int(height * 0.95)),
-                    augmax.Resize(width, height),
-                    augmax.Rotate((-5, 5)),
-                ]
-            transforms += [
+            height, width = image.shape[1:3]
+            # Follows pi0.5 Appendix E; the shared rng keeps per-frame augmentation
+            # parameters consistent across cameras.
+            transforms = [
+                augmax.RandomCrop(int(width * 0.95), int(height * 0.95)),
+                augmax.Resize(width, height),
+                augmax.Rotate((-5, 5)),
                 augmax.ColorJitter(brightness=0.3, contrast=0.4, saturation=0.5),
             ]
             sub_rngs = jax.random.split(rng, image.shape[0])

--- a/src/openpi/models/model_test.py
+++ b/src/openpi/models/model_test.py
@@ -1,5 +1,7 @@
 from flax import nnx
 import jax
+import jax.numpy as jnp
+import numpy as np
 import pytest
 
 from openpi.models import model as _model
@@ -7,6 +9,28 @@ from openpi.models import pi0_config
 from openpi.models import pi0_fast
 from openpi.shared import download
 from openpi.shared import nnx_utils
+
+
+def test_preprocess_observation_augmentation_consistent_across_cameras():
+    batch_size = 2
+    image = jnp.linspace(-1.0, 1.0, batch_size * 224 * 224 * 3, dtype=jnp.float32).reshape(batch_size, 224, 224, 3)
+    obs = _model.Observation(
+        images=dict.fromkeys(_model.IMAGE_KEYS, image),
+        image_masks={key: jnp.ones((batch_size,), dtype=jnp.bool) for key in _model.IMAGE_KEYS},
+        state=jnp.zeros((batch_size, 1), dtype=jnp.float32),
+    )
+
+    augmented = _model.preprocess_observation(jax.random.key(0), obs, train=True)
+
+    np.testing.assert_array_equal(augmented.images["base_0_rgb"], augmented.images["left_wrist_0_rgb"])
+    np.testing.assert_array_equal(augmented.images["base_0_rgb"], augmented.images["right_wrist_0_rgb"])
+    assert not np.array_equal(np.asarray(augmented.images["base_0_rgb"]), np.asarray(image))
+    assert jnp.min(augmented.images["base_0_rgb"]) >= -1.0 - 1e-6
+    assert jnp.max(augmented.images["base_0_rgb"]) <= 1.0 + 1e-6
+
+    not_augmented = _model.preprocess_observation(jax.random.key(0), obs, train=False)
+    for key in _model.IMAGE_KEYS:
+        np.testing.assert_array_equal(not_augmented.images[key], image)
 
 
 def test_pi0_model():


### PR DESCRIPTION
## Problem

`preprocess_observation` passes the same `rng` for every camera, which suggests augmentation parameters are meant to be consistent across cameras within a frame. They are not: `augmax.Chain` splits its key once per sub-transform, and the base camera chain has 4 transforms while wrist chains have 1, so `ColorJitter` draws different subkeys for base vs wrist. The same physical frame gets visibly different hue/brightness/contrast on the base camera vs the wrist cameras (#859 has a visual repro).

## Why this divergence matters

The pi0.5 paper (arXiv 2504.16054, Appendix E) describes the training recipe as applying the full chain to every input image:

> We apply image augmentation (random crop, resizing, rotation, and color jittering) to all input images using the following hyper-parameters and in this order

followed by exactly the `RandomCrop(0.95) -> Resize -> Rotate(+-5) -> ColorJitter(0.3, 0.4, 0.5)` chain this file uses. The wrist special case deviates from the recipe used to train the released checkpoints, and as a side effect breaks cross-camera color consistency through the Chain key-splitting described above.

## Fix

Apply the full augmentation chain to every camera image. With identical chains and the shared per-frame rng, all cameras receive identical augmentation parameters for a given frame, restoring cross-camera color consistency and matching the published recipe.

If the wrist exclusion from geometric augmentation was intentional, the minimal alternative is to keep the wrist chain geometric-free but give `ColorJitter` a dedicated key shared across cameras. Happy to switch this PR to that variant.

## Test

Adds `test_preprocess_observation_train_augmentations_consistent_across_cameras`: identical images on all three cameras, fixed key, asserts all augmented outputs are bitwise identical across cameras, actually differ from the input, stay within [-1, 1], and that `train=False` passes images through unchanged. Runs on CPU.

Fixes #859
