### PR TITLE
Restore z-score normalization for pi0_fast_libero configs

### DIFF
--- a/src/openpi/training/config.py
+++ b/src/openpi/training/config.py
@@ -171,6 +171,10 @@ class DataConfigFactory(abc.ABC):
     assets: AssetsConfig = dataclasses.field(default_factory=AssetsConfig)
     # Base config that will be updated by the factory.
     base_config: tyro.conf.Suppress[DataConfig | None] = None
+    # If set, overrides the model-type-based default for quantile normalization.
+    # Released pi0-FAST LIBERO checkpoints were trained with z-score normalization,
+    # so their configs pin this to False for checkpoint compatibility.
+    use_quantile_norm_override: bool | None = None
 
     @abc.abstractmethod
     def create(self, assets_dirs: pathlib.Path, model_config: _model.BaseModelConfig) -> DataConfig:
@@ -184,7 +188,9 @@ class DataConfigFactory(abc.ABC):
             repo_id=repo_id,
             asset_id=asset_id,
             norm_stats=self._load_norm_stats(epath.Path(self.assets.assets_dir or assets_dirs), asset_id),
-            use_quantile_norm=model_config.model_type != ModelType.PI0,
+            use_quantile_norm=self.use_quantile_norm_override
+            if self.use_quantile_norm_override is not None
+            else model_config.model_type != ModelType.PI0,
         )
 
     def _load_norm_stats(self, assets_dir: epath.Path, asset_id: str | None) -> dict[str, _transforms.NormStats] | None:
@@ -713,6 +719,9 @@ _CONFIGS = [
             repo_id="physical-intelligence/libero",
             base_config=DataConfig(prompt_from_task=True),
             extra_delta_transform=True,
+            # The released pi0_fast_libero checkpoint predates the quantile-norm default for non-PI0
+            # models and was trained with z-score normalization, so keep normalization z-score.
+            use_quantile_norm_override=False,
         ),
         # Note that we load the pi0-FAST base model checkpoint here.
         weight_loader=weight_loaders.CheckpointWeightLoader("gs://openpi-assets/checkpoints/pi0_fast_base/params"),
@@ -729,6 +738,9 @@ _CONFIGS = [
             repo_id="physical-intelligence/libero",
             base_config=DataConfig(prompt_from_task=True),
             extra_delta_transform=True,
+            # The released pi0_fast_libero checkpoint predates the quantile-norm default for non-PI0
+            # models and was trained with z-score normalization, so keep normalization z-score.
+            use_quantile_norm_override=False,
         ),
         weight_loader=weight_loaders.CheckpointWeightLoader("gs://openpi-assets/checkpoints/pi0_fast_base/params"),
         num_train_steps=30_000,


### PR DESCRIPTION
## Problem

Evaluating the official `pi0_fast_libero` checkpoint on current main gives ~0% success on LIBERO (the arm spins in place). #849 has six independent reports, and one user bisected the last working commit to e4580662.

## Root cause

At e4580662, `LeRobotLiberoDataConfig` built its `DataConfig` without setting `use_quantile_norm`, so the pi0-FAST LIBERO configs trained and served with z-score normalization. Current main's `DataConfigFactory.create_base_config` force-sets `use_quantile_norm = model_type != PI0`, which silently flipped `pi0_fast_libero` and `pi0_fast_libero_low_mem_finetune` to quantile normalization. The released checkpoint was trained with z-score stats, so the state input is mis-normalized going in and the action chunk is mis-unnormalized coming out. The scale mismatch on actions is what produces the spinning-arm behavior. DROID FAST configs are unaffected; they used quantile normalization both before and after that change.

## Evidence

Deterministic probe: the official checkpoint, a fixed synthetic LIBERO observation, greedy FAST decoding, run at e4580662 and at current main. Preprocessed image hashes and transform sequences are identical at both commits, but:

- post-normalization state vector differs by up to 10.36
- FAST token ids diverge at 5 positions
- action chunks differ with max abs diff 2.64

With this PR applied to main, the same probe reproduces e4580662's post-normalization state, token ids, and both action chunks exactly (max abs diff 0 on all four checks, two infer calls each).

## Change

- `DataConfigFactory` gains `use_quantile_norm_override: bool | None` (default None keeps the model-type default for every existing config).
- The two `pi0_fast_libero` configs pin the override to False with a comment explaining the checkpoint compatibility constraint.

Flag matrix after the change: `pi0_fast_libero` False, `pi0_fast_libero_low_mem_finetune` False, `pi0_fast_droid` True, `pi0_libero` False, `pi05_libero` True.

`ruff check` and `ruff format --check` pass. `data_loader_test.py`: 4 passed, plus `test_with_real_dataset` which fails identically on clean main (pre-existing dataset-fetch issue, unrelated).

## Caveat

Anyone who finetuned pi0-FAST on LIBERO with current main trained under quantile normalization; for those checkpoints the override makes the choice explicit and per-config instead of a silent default flip.

Fixes #849