### PR TITLE
Update output objects to support batching

### DIFF
--- a/src/openpi/policies/droid_policy.py
+++ b/src/openpi/policies/droid_policy.py
@@ -78,4 +78,4 @@ class DroidInputs(transforms.DataTransformFn):
 class DroidOutputs(transforms.DataTransformFn):
     def __call__(self, data: dict) -> dict:
         # Only return the first 8 dims.
-        return {"actions": np.asarray(data["actions"][:, :8])}
+        return {"actions": np.asarray(data["actions"][..., :8])}

--- a/src/openpi/policies/libero_policy.py
+++ b/src/openpi/policies/libero_policy.py
@@ -97,4 +97,4 @@ class LiberoOutputs(transforms.DataTransformFn):
         # dimension, we need to now parse out the correct number of actions in the return dict.
         # For Libero, we only return the first 7 actions (since the rest is padding).
         # For your own dataset, replace `7` with the action dimension of your dataset.
-        return {"actions": np.asarray(data["actions"][:, :7])}
+        return {"actions": np.asarray(data["actions"][..., :7])}


### PR DESCRIPTION
Right now, LiberoOutputs and DroidOutputs are hardcoded to think that the second axis is the action dims, when it comes to removing the padding. This is a problem when running batched inference, as the output is then [batch size, chunk len, padded action dims]. Simple fix: instead of hardcoded to be second axis, set it to be the last.

`[:, :<max action dim>] --> [..., :<max action dim>]`

This is functionally identical to the past version for all unbatched use cases.