### PR TITLE
Prevent PI0/PI05 JAX to PyTorch weight precision drift.

### DIFF
--- a/examples/convert_jax_model_to_pytorch.py
+++ b/examples/convert_jax_model_to_pytorch.py
@@ -26,6 +26,7 @@ Example:
     python examples/convert_jax_model_to_pytorch.py --checkpoint_dir /home/$USER/.cache/openpi/openpi-assets/checkpoints/pi05_droid --output_path /home/$USER/.cache/openpi/openpi-assets/checkpoints/pi05_droid_pytorch
 """
 
+import dataclasses
 import json
 import os
 import pathlib
@@ -436,6 +437,9 @@ def convert_pi0_checkpoint(
 
     # Break down orbax ckpts by restoring via JAX to respect dtype
     initial_params = slice_initial_orbax_checkpoint(checkpoint_dir=checkpoint_dir, restore_precision="float32")
+    if model_config.dtype != "float32":
+        print(f"Using float32 for conversion instead of config dtype={model_config.dtype!r}")
+        model_config = dataclasses.replace(model_config, dtype="float32")
 
     # Process projection params
     if model_config.pi05:


### PR DESCRIPTION
  ## Summary

  This PR adds a small safeguard to the JAX-to-PyTorch checkpoint conversion path for PI0-family models, including PI0 and PI05.

  During conversion, the model config dtype is forced to `float32` internally if the source config uses another dtype. This avoids accidental precision loss in the intermediate PyTorch checkpoint and helps keep JAX and PyTorch weights
  numerically aligned.

  ## Motivation

  During OpenPI inference acceleration work, we need the following path to stay numerically aligned:

  ```text
  JAX checkpoint -> PyTorch checkpoint -> downstream accelerated framework

  For this pipeline, JAX and PyTorch should be able to produce fully aligned inference results when inputs, weights, and precision settings match. If the PyTorch checkpoint is built with a lower-precision model config during
  conversion, fp32 weight precision can be lost before downstream conversion or debugging, making it harder to distinguish real backend differences from conversion artifacts.

  This change adds a defensive guard so PI0/PI05 conversion restores and constructs the PyTorch model in fp32 internally, while keeping the existing CLI output precision behavior unchanged.

  ## Changes

  - Import dataclasses
  - During PI0-family checkpoint conversion, replace model_config.dtype with "float32" when needed
  - Keep the existing precision CLI default and options unchanged

  ## Notes

  This does not change the requested output precision. It only prevents the model config dtype from silently reducing internal conversion precision before the final save step.
