### PR TITLE
Fail on unmerged LoRA keys during JAX conversion

### DIFF
--- a/examples/convert_jax_model_to_pytorch.py
+++ b/examples/convert_jax_model_to_pytorch.py
@@ -517,7 +517,14 @@ def convert_pi0_checkpoint(
     all_params = {**paligemma_params, **gemma_params, **projection_params}
 
     # Load state dict
-    pi0_model.load_state_dict(all_params, strict=False)
+    load_result = pi0_model.load_state_dict(all_params, strict=False)
+    unexpected_lora_keys = [key for key in load_result.unexpected_keys if "lora" in key.lower()]
+    if unexpected_lora_keys:
+        raise ValueError(
+            "LoRA adapter weights were found after conversion, but this converter does not merge LoRA adapters yet. "
+            "Saving this checkpoint would silently drop the adapters and produce incorrect PyTorch weights. "
+            f"Unexpected LoRA keys: {unexpected_lora_keys}"
+        )
 
     if precision == "float32":
         pi0_model = pi0_model.to(torch.float32)


### PR DESCRIPTION
Summary
- Capture load_state_dict results in the JAX to PyTorch converter
- Raise a clear error when unexpected LoRA keys remain after conversion
- Prevent saving PyTorch checkpoints that would silently drop LoRA adapters

Scope
- This is a guard against incorrect converted weights
- It does not implement LoRA adapter merging

Verification
- python3 -m py_compile examples/convert_jax_model_to_pytorch.py
- git diff --check

Addresses #958