### PR TITLE
Fix Jetson Python 3.10 and WebSocket compatibility #1011

### DIFF
--- a/packages/openpi-client/src/openpi_client/websocket_client_policy.py
+++ b/packages/openpi-client/src/openpi_client/websocket_client_policy.py
@@ -35,7 +35,12 @@ class WebsocketClientPolicy(_base_policy.BasePolicy):
             try:
                 headers = {"Authorization": f"Api-Key {self._api_key}"} if self._api_key else None
                 conn = websockets.sync.client.connect(
-                    self._uri, compression=None, max_size=None, additional_headers=headers
+                    self._uri,
+                    compression=None,
+                    max_size=None,
+                    additional_headers=headers,
+                    ping_interval=None,
+                    open_timeout=None,
                 )
                 metadata = msgpack_numpy.unpackb(conn.recv())
                 return conn, metadata

--- a/src/openpi/shared/download.py
+++ b/src/openpi/shared/download.py
@@ -188,7 +188,7 @@ def _ensure_permissions(path: pathlib.Path) -> None:
 
 def _get_mtime(year: int, month: int, day: int) -> float:
     """Get the mtime of a given date at midnight UTC."""
-    date = datetime.datetime(year, month, day, tzinfo=datetime.UTC)
+    date = datetime.datetime(year, month, day, tzinfo=datetime.timezone.utc)
     return time.mktime(date.timetuple())
 
 


### PR DESCRIPTION
Use a Python 3.10-compatible UTC timezone and prevent WebSocket startup and keepalive timeouts during Jetson deployment.

my issue
https://github.com/Physical-Intelligence/openpi/issues/1011

